### PR TITLE
feat: Implement @probitas/client-sql core package

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,8 @@
 {
   "workspace": [
     "./packages/probitas-client",
-    "./packages/probitas-client-http"
+    "./packages/probitas-client-http",
+    "./packages/probitas-client-sql"
   ],
   "exclude": [
     ".coverage/**",
@@ -19,6 +20,8 @@
     "@std/path": "jsr:@std/path@^1.0.8",
     "@std/semver": "jsr:@std/semver@^1.0.4",
     "@std/testing": "jsr:@std/testing@^1.0.16",
-    "jsr:@probitas/client@^0": "./packages/probitas-client/mod.ts"
+    "jsr:@probitas/client@^0": "./packages/probitas-client/mod.ts",
+    "jsr:@probitas/client-http@^0": "./packages/probitas-client-http/mod.ts",
+    "jsr:@probitas/client-sql@^0": "./packages/probitas-client-sql/mod.ts"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,18 +1,37 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/assert@^1.0.16": "1.0.16",
+    "jsr:@std/async@^1.0.15": "1.0.15",
+    "jsr:@std/data-structures@^1.0.9": "1.0.9",
+    "jsr:@std/fs@^1.0.19": "1.0.20",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/json@^1.0.2": "1.0.2",
     "jsr:@std/jsonc@^1.0.1": "1.0.2",
     "jsr:@std/path@^1.0.8": "1.1.3",
-    "jsr:@std/semver@^1.0.4": "1.0.7"
+    "jsr:@std/path@^1.1.2": "1.1.3",
+    "jsr:@std/path@^1.1.3": "1.1.3",
+    "jsr:@std/semver@^1.0.4": "1.0.7",
+    "jsr:@std/testing@^1.0.16": "1.0.16"
   },
   "jsr": {
     "@std/assert@1.0.16": {
       "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
       "dependencies": [
         "jsr:@std/internal"
+      ]
+    },
+    "@std/async@1.0.15": {
+      "integrity": "55d1d9d04f99403fe5730ab16bdcc3c47f658a6bf054cafb38a50f046238116e"
+    },
+    "@std/data-structures@1.0.9": {
+      "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
+    },
+    "@std/fs@1.0.20": {
+      "integrity": "e953206aae48d46ee65e8783ded459f23bec7dd1f3879512911c35e5484ea187",
+      "dependencies": [
+        "jsr:@std/path@^1.1.3"
       ]
     },
     "@std/internal@1.0.12": {
@@ -35,6 +54,17 @@
     },
     "@std/semver@1.0.7": {
       "integrity": "7d5f65391762dc4358abde80fc3354086ddb40101f140295e60f290c138887d0"
+    },
+    "@std/testing@1.0.16": {
+      "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.15",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs",
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.2"
+      ]
     }
   },
   "workspace": {
@@ -47,6 +77,11 @@
     ],
     "members": {
       "packages/probitas-client-http": {
+        "dependencies": [
+          "jsr:@probitas/client@0"
+        ]
+      },
+      "packages/probitas-client-sql": {
         "dependencies": [
           "jsr:@probitas/client@0"
         ]

--- a/packages/probitas-client-sql/deno.json
+++ b/packages/probitas-client-sql/deno.json
@@ -1,0 +1,11 @@
+{
+  "name": "@probitas/client-sql",
+  "version": "0.0.0",
+  "exports": "./mod.ts",
+  "publish": {
+    "exclude": ["**/*_test.ts", "**/*_bench.ts"]
+  },
+  "imports": {
+    "@probitas/client": "jsr:@probitas/client@^0"
+  }
+}

--- a/packages/probitas-client-sql/errors.ts
+++ b/packages/probitas-client-sql/errors.ts
@@ -1,0 +1,76 @@
+import { ClientError } from "@probitas/client";
+
+/**
+ * SQL-specific error kinds.
+ */
+export type SqlErrorKind =
+  | "query"
+  | "constraint"
+  | "deadlock"
+  | "unknown";
+
+/**
+ * Options for SqlError constructor.
+ */
+export interface SqlErrorOptions extends ErrorOptions {
+  /** SQL State code (e.g., "23505" for unique violation) */
+  readonly sqlState?: string;
+}
+
+/**
+ * Base error class for SQL-specific errors.
+ * Extends ClientError with SQL-specific properties.
+ */
+export class SqlError extends ClientError {
+  override readonly name: string = "SqlError";
+  override readonly kind: SqlErrorKind;
+  readonly sqlState?: string;
+
+  constructor(
+    message: string,
+    kind: SqlErrorKind,
+    options?: SqlErrorOptions,
+  ) {
+    super(message, kind, options);
+    this.kind = kind;
+    this.sqlState = options?.sqlState;
+  }
+}
+
+/**
+ * Error thrown when a SQL query has syntax errors.
+ */
+export class QuerySyntaxError extends SqlError {
+  override readonly name = "QuerySyntaxError";
+  override readonly kind = "query" as const;
+
+  constructor(message: string, options?: SqlErrorOptions) {
+    super(message, "query", options);
+  }
+}
+
+/**
+ * Error thrown when a constraint violation occurs.
+ */
+export class ConstraintError extends SqlError {
+  override readonly name = "ConstraintError";
+  override readonly kind = "constraint" as const;
+  readonly constraint: string;
+
+  constructor(message: string, constraint: string, options?: SqlErrorOptions) {
+    super(message, "constraint", options);
+    this.constraint = constraint;
+  }
+}
+
+/**
+ * Error thrown when a deadlock is detected.
+ */
+export class DeadlockError extends SqlError {
+  override readonly name = "DeadlockError";
+  override readonly kind = "deadlock" as const;
+
+  constructor(message: string, options?: SqlErrorOptions) {
+    super(message, "deadlock", options);
+  }
+}

--- a/packages/probitas-client-sql/errors_test.ts
+++ b/packages/probitas-client-sql/errors_test.ts
@@ -1,0 +1,113 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { ClientError } from "@probitas/client";
+import {
+  ConstraintError,
+  DeadlockError,
+  QuerySyntaxError,
+  SqlError,
+} from "./errors.ts";
+
+Deno.test("SqlError", async (t) => {
+  await t.step("extends ClientError", () => {
+    const error = new SqlError("SQL error", "unknown");
+    assertInstanceOf(error, ClientError);
+    assertInstanceOf(error, Error);
+  });
+
+  await t.step("has correct name and kind", () => {
+    const error = new SqlError("SQL error", "query");
+    assertEquals(error.name, "SqlError");
+    assertEquals(error.kind, "query");
+    assertEquals(error.message, "SQL error");
+  });
+
+  await t.step("accepts sqlState", () => {
+    const error = new SqlError("Unique violation", "constraint", {
+      sqlState: "23505",
+    });
+    assertEquals(error.sqlState, "23505");
+  });
+
+  await t.step("supports cause option", () => {
+    const cause = new Error("Original error");
+    const error = new SqlError("SQL error", "unknown", { cause });
+    assertEquals(error.cause, cause);
+  });
+
+  await t.step("supports both sqlState and cause", () => {
+    const cause = new Error("Original error");
+    const error = new SqlError("SQL error", "constraint", {
+      sqlState: "23505",
+      cause,
+    });
+    assertEquals(error.sqlState, "23505");
+    assertEquals(error.cause, cause);
+  });
+});
+
+Deno.test("QuerySyntaxError", async (t) => {
+  await t.step("extends SqlError and ClientError", () => {
+    const error = new QuerySyntaxError("Syntax error near SELECT");
+    assertInstanceOf(error, SqlError);
+    assertInstanceOf(error, ClientError);
+    assertInstanceOf(error, Error);
+  });
+
+  await t.step("has correct name and kind", () => {
+    const error = new QuerySyntaxError("Syntax error");
+    assertEquals(error.name, "QuerySyntaxError");
+    assertEquals(error.kind, "query");
+  });
+
+  await t.step("accepts sqlState", () => {
+    const error = new QuerySyntaxError("Syntax error", { sqlState: "42601" });
+    assertEquals(error.sqlState, "42601");
+  });
+});
+
+Deno.test("ConstraintError", async (t) => {
+  await t.step("extends SqlError and ClientError", () => {
+    const error = new ConstraintError("Unique violation", "users_email_key");
+    assertInstanceOf(error, SqlError);
+    assertInstanceOf(error, ClientError);
+    assertInstanceOf(error, Error);
+  });
+
+  await t.step("has correct name and kind", () => {
+    const error = new ConstraintError("Unique violation", "users_email_key");
+    assertEquals(error.name, "ConstraintError");
+    assertEquals(error.kind, "constraint");
+  });
+
+  await t.step("has constraint property", () => {
+    const error = new ConstraintError("Unique violation", "users_email_key");
+    assertEquals(error.constraint, "users_email_key");
+  });
+
+  await t.step("accepts sqlState", () => {
+    const error = new ConstraintError("Unique violation", "users_email_key", {
+      sqlState: "23505",
+    });
+    assertEquals(error.sqlState, "23505");
+  });
+});
+
+Deno.test("DeadlockError", async (t) => {
+  await t.step("extends SqlError and ClientError", () => {
+    const error = new DeadlockError("Deadlock detected");
+    assertInstanceOf(error, SqlError);
+    assertInstanceOf(error, ClientError);
+    assertInstanceOf(error, Error);
+  });
+
+  await t.step("has correct name and kind", () => {
+    const error = new DeadlockError("Deadlock detected");
+    assertEquals(error.name, "DeadlockError");
+    assertEquals(error.kind, "deadlock");
+  });
+
+  await t.step("accepts sqlState", () => {
+    const error = new DeadlockError("Deadlock detected", { sqlState: "40P01" });
+    assertEquals(error.sqlState, "40P01");
+  });
+});

--- a/packages/probitas-client-sql/expectation.ts
+++ b/packages/probitas-client-sql/expectation.ts
@@ -1,0 +1,241 @@
+import type { SqlQueryResult } from "./result.ts";
+import type { SqlRows } from "./rows.ts";
+
+/**
+ * Expectation interface for SQL query results.
+ * All methods return `this` for chaining.
+ */
+export interface SqlQueryResultExpectation<T> {
+  /** Verify query succeeded */
+  ok(): this;
+
+  /** Verify query failed */
+  notOk(): this;
+
+  /** Verify result has no rows */
+  noContent(): this;
+
+  /** Verify result has rows */
+  hasContent(): this;
+
+  /** Verify exact row count */
+  rows(count: number): this;
+
+  /** Verify minimum row count */
+  rowsAtLeast(count: number): this;
+
+  /** Verify maximum row count */
+  rowsAtMost(count: number): this;
+
+  /** Verify exact affected row count */
+  rowCount(count: number): this;
+
+  /** Verify minimum affected row count */
+  rowCountAtLeast(count: number): this;
+
+  /** Verify maximum affected row count */
+  rowCountAtMost(count: number): this;
+
+  /** Verify a row contains the given subset */
+  rowContains(subset: Partial<T>): this;
+
+  /** Custom row validation */
+  rowMatch(matcher: (rows: SqlRows<T>) => void): this;
+
+  /** Verify mapped data contains the given subset */
+  mapContains<U>(mapper: (row: T) => U, subset: Partial<U>): this;
+
+  /** Custom mapped data validation */
+  mapMatch<U>(mapper: (row: T) => U, matcher: (mapped: U[]) => void): this;
+
+  /** Verify instance contains the given subset */
+  asContains<U>(ctor: new (row: T) => U, subset: Partial<U>): this;
+
+  /** Custom instance validation */
+  asMatch<U>(ctor: new (row: T) => U, matcher: (instances: U[]) => void): this;
+
+  /** Verify exact lastInsertId */
+  lastInsertId(expected: bigint | string): this;
+
+  /** Verify lastInsertId is present */
+  hasLastInsertId(): this;
+
+  /** Verify query duration is below threshold */
+  durationLessThan(ms: number): this;
+}
+
+/**
+ * Implementation of SqlQueryResultExpectation.
+ */
+class SqlQueryResultExpectationImpl<T> implements SqlQueryResultExpectation<T> {
+  constructor(private readonly result: SqlQueryResult<T>) {}
+
+  ok(): this {
+    if (!this.result.ok) {
+      throw new Error("Expected query to succeed");
+    }
+    return this;
+  }
+
+  notOk(): this {
+    if (this.result.ok) {
+      throw new Error("Expected query to fail");
+    }
+    return this;
+  }
+
+  noContent(): this {
+    if (this.result.rows.length > 0) {
+      throw new Error(`Expected no rows, got ${this.result.rows.length}`);
+    }
+    return this;
+  }
+
+  hasContent(): this {
+    if (this.result.rows.length === 0) {
+      throw new Error("Expected rows to be present");
+    }
+    return this;
+  }
+
+  rows(count: number): this {
+    if (this.result.rows.length !== count) {
+      throw new Error(
+        `Expected ${count} rows, got ${this.result.rows.length}`,
+      );
+    }
+    return this;
+  }
+
+  rowsAtLeast(count: number): this {
+    if (this.result.rows.length < count) {
+      throw new Error(
+        `Expected at least ${count} rows, got ${this.result.rows.length}`,
+      );
+    }
+    return this;
+  }
+
+  rowsAtMost(count: number): this {
+    if (this.result.rows.length > count) {
+      throw new Error(
+        `Expected at most ${count} rows, got ${this.result.rows.length}`,
+      );
+    }
+    return this;
+  }
+
+  rowCount(count: number): this {
+    if (this.result.rowCount !== count) {
+      throw new Error(
+        `Expected rowCount ${count}, got ${this.result.rowCount}`,
+      );
+    }
+    return this;
+  }
+
+  rowCountAtLeast(count: number): this {
+    if (this.result.rowCount < count) {
+      throw new Error(
+        `Expected rowCount at least ${count}, got ${this.result.rowCount}`,
+      );
+    }
+    return this;
+  }
+
+  rowCountAtMost(count: number): this {
+    if (this.result.rowCount > count) {
+      throw new Error(
+        `Expected rowCount at most ${count}, got ${this.result.rowCount}`,
+      );
+    }
+    return this;
+  }
+
+  rowContains(subset: Partial<T>): this {
+    const found = this.result.rows.find((row) =>
+      this.containsSubset(row, subset)
+    );
+    if (!found) {
+      throw new Error("No row contains the expected subset");
+    }
+    return this;
+  }
+
+  rowMatch(matcher: (rows: SqlRows<T>) => void): this {
+    matcher(this.result.rows);
+    return this;
+  }
+
+  mapContains<U>(mapper: (row: T) => U, subset: Partial<U>): this {
+    const mapped = this.result.map(mapper);
+    const found = mapped.find((item) => this.containsSubset(item, subset));
+    if (!found) {
+      throw new Error("No mapped row contains the expected subset");
+    }
+    return this;
+  }
+
+  mapMatch<U>(mapper: (row: T) => U, matcher: (mapped: U[]) => void): this {
+    const mapped = this.result.map(mapper);
+    matcher(mapped);
+    return this;
+  }
+
+  asContains<U>(ctor: new (row: T) => U, subset: Partial<U>): this {
+    const instances = this.result.as(ctor);
+    const found = instances.find((item) => this.containsSubset(item, subset));
+    if (!found) {
+      throw new Error("No instance contains the expected subset");
+    }
+    return this;
+  }
+
+  asMatch<U>(ctor: new (row: T) => U, matcher: (instances: U[]) => void): this {
+    const instances = this.result.as(ctor);
+    matcher(instances);
+    return this;
+  }
+
+  lastInsertId(expected: bigint | string): this {
+    const actual = this.result.metadata.lastInsertId;
+    if (actual !== expected) {
+      throw new Error(`Expected lastInsertId ${expected}, got ${actual}`);
+    }
+    return this;
+  }
+
+  hasLastInsertId(): this {
+    if (this.result.metadata.lastInsertId === undefined) {
+      throw new Error("Expected lastInsertId to be present");
+    }
+    return this;
+  }
+
+  durationLessThan(ms: number): this {
+    if (this.result.duration >= ms) {
+      throw new Error(
+        `Expected duration < ${ms}ms, got ${this.result.duration}ms`,
+      );
+    }
+    return this;
+  }
+
+  private containsSubset<V>(obj: V, subset: Partial<V>): boolean {
+    for (const key of Object.keys(subset) as (keyof V)[]) {
+      if (obj[key] !== subset[key]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+/**
+ * Create an expectation for a SQL query result.
+ */
+export function expectSqlQueryResult<T = Record<string, unknown>>(
+  result: SqlQueryResult<T>,
+): SqlQueryResultExpectation<T> {
+  return new SqlQueryResultExpectationImpl(result);
+}

--- a/packages/probitas-client-sql/expectation_test.ts
+++ b/packages/probitas-client-sql/expectation_test.ts
@@ -1,0 +1,307 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { SqlQueryResult } from "./result.ts";
+import { expectSqlQueryResult } from "./expectation.ts";
+
+function createResult<T>(
+  rows: T[],
+  options: {
+    ok?: boolean;
+    rowCount?: number;
+    duration?: number;
+    lastInsertId?: bigint | string;
+    warnings?: string[];
+  } = {},
+): SqlQueryResult<T> {
+  return new SqlQueryResult({
+    ok: options.ok ?? true,
+    rows,
+    rowCount: options.rowCount ?? 0,
+    duration: options.duration ?? 10,
+    metadata: {
+      lastInsertId: options.lastInsertId,
+      warnings: options.warnings,
+    },
+  });
+}
+
+Deno.test("expectSqlQueryResult", async (t) => {
+  await t.step("ok() passes for successful result", () => {
+    const result = createResult([{ id: 1 }]);
+    expectSqlQueryResult(result).ok();
+  });
+
+  await t.step("ok() fails for failed result", () => {
+    const result = createResult([], { ok: false });
+    assertThrows(
+      () => expectSqlQueryResult(result).ok(),
+      Error,
+      "Expected query to succeed",
+    );
+  });
+
+  await t.step("notOk() passes for failed result", () => {
+    const result = createResult([], { ok: false });
+    expectSqlQueryResult(result).notOk();
+  });
+
+  await t.step("notOk() fails for successful result", () => {
+    const result = createResult([{ id: 1 }]);
+    assertThrows(
+      () => expectSqlQueryResult(result).notOk(),
+      Error,
+      "Expected query to fail",
+    );
+  });
+
+  await t.step("noContent() passes for empty result", () => {
+    const result = createResult([]);
+    expectSqlQueryResult(result).noContent();
+  });
+
+  await t.step("noContent() fails for non-empty result", () => {
+    const result = createResult([{ id: 1 }]);
+    assertThrows(
+      () => expectSqlQueryResult(result).noContent(),
+      Error,
+      "Expected no rows",
+    );
+  });
+
+  await t.step("hasContent() passes for non-empty result", () => {
+    const result = createResult([{ id: 1 }]);
+    expectSqlQueryResult(result).hasContent();
+  });
+
+  await t.step("hasContent() fails for empty result", () => {
+    const result = createResult([]);
+    assertThrows(
+      () => expectSqlQueryResult(result).hasContent(),
+      Error,
+      "Expected rows to be present",
+    );
+  });
+
+  await t.step("rows() passes for exact count", () => {
+    const result = createResult([{ id: 1 }, { id: 2 }]);
+    expectSqlQueryResult(result).rows(2);
+  });
+
+  await t.step("rows() fails for incorrect count", () => {
+    const result = createResult([{ id: 1 }]);
+    assertThrows(
+      () => expectSqlQueryResult(result).rows(2),
+      Error,
+      "Expected 2 rows, got 1",
+    );
+  });
+
+  await t.step("rowsAtLeast() passes for sufficient rows", () => {
+    const result = createResult([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expectSqlQueryResult(result).rowsAtLeast(2);
+  });
+
+  await t.step("rowsAtLeast() fails for insufficient rows", () => {
+    const result = createResult([{ id: 1 }]);
+    assertThrows(
+      () => expectSqlQueryResult(result).rowsAtLeast(2),
+      Error,
+      "Expected at least 2 rows, got 1",
+    );
+  });
+
+  await t.step("rowsAtMost() passes for acceptable rows", () => {
+    const result = createResult([{ id: 1 }]);
+    expectSqlQueryResult(result).rowsAtMost(2);
+  });
+
+  await t.step("rowsAtMost() fails for too many rows", () => {
+    const result = createResult([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    assertThrows(
+      () => expectSqlQueryResult(result).rowsAtMost(2),
+      Error,
+      "Expected at most 2 rows, got 3",
+    );
+  });
+
+  await t.step("rowCount() passes for exact count", () => {
+    const result = createResult([], { rowCount: 5 });
+    expectSqlQueryResult(result).rowCount(5);
+  });
+
+  await t.step("rowCount() fails for incorrect count", () => {
+    const result = createResult([], { rowCount: 3 });
+    assertThrows(
+      () => expectSqlQueryResult(result).rowCount(5),
+      Error,
+      "Expected rowCount 5, got 3",
+    );
+  });
+
+  await t.step("rowCountAtLeast() passes for sufficient count", () => {
+    const result = createResult([], { rowCount: 5 });
+    expectSqlQueryResult(result).rowCountAtLeast(3);
+  });
+
+  await t.step("rowCountAtLeast() fails for insufficient count", () => {
+    const result = createResult([], { rowCount: 2 });
+    assertThrows(
+      () => expectSqlQueryResult(result).rowCountAtLeast(3),
+      Error,
+      "Expected rowCount at least 3, got 2",
+    );
+  });
+
+  await t.step("rowCountAtMost() passes for acceptable count", () => {
+    const result = createResult([], { rowCount: 3 });
+    expectSqlQueryResult(result).rowCountAtMost(5);
+  });
+
+  await t.step("rowCountAtMost() fails for excessive count", () => {
+    const result = createResult([], { rowCount: 10 });
+    assertThrows(
+      () => expectSqlQueryResult(result).rowCountAtMost(5),
+      Error,
+      "Expected rowCount at most 5, got 10",
+    );
+  });
+
+  await t.step("rowContains() passes for matching row", () => {
+    const result = createResult([
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+    ]);
+    expectSqlQueryResult(result).rowContains({ name: "Alice" });
+  });
+
+  await t.step("rowContains() fails for no matching row", () => {
+    const result = createResult([
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+    ]);
+    assertThrows(
+      () => expectSqlQueryResult(result).rowContains({ name: "Charlie" }),
+      Error,
+      "No row contains the expected subset",
+    );
+  });
+
+  await t.step("rowMatch() passes for valid matcher", () => {
+    const result = createResult([{ id: 1 }, { id: 2 }]);
+    expectSqlQueryResult(result).rowMatch((rows) => {
+      assertEquals(rows.length, 2);
+    });
+  });
+
+  await t.step("rowMatch() fails for failing matcher", () => {
+    const result = createResult([{ id: 1 }]);
+    assertThrows(
+      () =>
+        expectSqlQueryResult(result).rowMatch((rows) => {
+          assertEquals(rows.length, 2);
+        }),
+      Error,
+    );
+  });
+
+  await t.step("mapContains() passes for matching mapped row", () => {
+    const result = createResult([{ id: 1, firstName: "Alice", lastName: "A" }]);
+    expectSqlQueryResult(result).mapContains(
+      (row) => ({ fullName: `${row.firstName} ${row.lastName}` }),
+      { fullName: "Alice A" },
+    );
+  });
+
+  await t.step("mapMatch() passes for valid mapped matcher", () => {
+    const result = createResult([{ id: 1, value: 10 }, { id: 2, value: 20 }]);
+    expectSqlQueryResult(result).mapMatch(
+      (row) => row.value * 2,
+      (mapped) => {
+        assertEquals(mapped, [20, 40]);
+      },
+    );
+  });
+
+  await t.step("asContains() passes for matching instance", () => {
+    class User {
+      readonly displayName: string;
+      constructor(row: { name: string }) {
+        this.displayName = `User: ${row.name}`;
+      }
+    }
+    const result = createResult([{ name: "Alice" }]);
+    expectSqlQueryResult(result).asContains(User, {
+      displayName: "User: Alice",
+    });
+  });
+
+  await t.step("asMatch() passes for valid instance matcher", () => {
+    class User {
+      readonly id: number;
+      constructor(row: { id: number }) {
+        this.id = row.id;
+      }
+    }
+    const result = createResult([{ id: 1 }, { id: 2 }]);
+    expectSqlQueryResult(result).asMatch(User, (instances) => {
+      assertEquals(instances.map((u) => u.id), [1, 2]);
+    });
+  });
+
+  await t.step("lastInsertId() passes for matching id", () => {
+    const result = createResult([], { lastInsertId: 42n });
+    expectSqlQueryResult(result).lastInsertId(42n);
+  });
+
+  await t.step("lastInsertId() fails for non-matching id", () => {
+    const result = createResult([], { lastInsertId: 42n });
+    assertThrows(
+      () => expectSqlQueryResult(result).lastInsertId(100n),
+      Error,
+      "Expected lastInsertId 100, got 42",
+    );
+  });
+
+  await t.step("hasLastInsertId() passes when present", () => {
+    const result = createResult([], { lastInsertId: 1n });
+    expectSqlQueryResult(result).hasLastInsertId();
+  });
+
+  await t.step("hasLastInsertId() fails when absent", () => {
+    const result = createResult([]);
+    assertThrows(
+      () => expectSqlQueryResult(result).hasLastInsertId(),
+      Error,
+      "Expected lastInsertId to be present",
+    );
+  });
+
+  await t.step("durationLessThan() passes for fast query", () => {
+    const result = createResult([], { duration: 50 });
+    expectSqlQueryResult(result).durationLessThan(100);
+  });
+
+  await t.step("durationLessThan() fails for slow query", () => {
+    const result = createResult([], { duration: 150 });
+    assertThrows(
+      () => expectSqlQueryResult(result).durationLessThan(100),
+      Error,
+      "Expected duration < 100ms, got 150ms",
+    );
+  });
+
+  await t.step("supports method chaining", () => {
+    const result = createResult([{ id: 1, name: "Alice" }], {
+      rowCount: 1,
+      duration: 10,
+      lastInsertId: 1n,
+    });
+    expectSqlQueryResult(result)
+      .ok()
+      .hasContent()
+      .rows(1)
+      .rowCount(1)
+      .rowContains({ name: "Alice" })
+      .hasLastInsertId()
+      .durationLessThan(100);
+  });
+});

--- a/packages/probitas-client-sql/mod.ts
+++ b/packages/probitas-client-sql/mod.ts
@@ -1,0 +1,26 @@
+// Rows
+export { SqlRows } from "./rows.ts";
+
+// Result
+export { SqlQueryResult } from "./result.ts";
+export type { SqlQueryResultInit, SqlQueryResultMetadata } from "./result.ts";
+
+// Transaction
+export type {
+  SqlIsolationLevel,
+  SqlTransaction,
+  SqlTransactionOptions,
+} from "./transaction.ts";
+
+// Errors
+export {
+  ConstraintError,
+  DeadlockError,
+  QuerySyntaxError,
+  SqlError,
+} from "./errors.ts";
+export type { SqlErrorKind, SqlErrorOptions } from "./errors.ts";
+
+// Expectation
+export { expectSqlQueryResult } from "./expectation.ts";
+export type { SqlQueryResultExpectation } from "./expectation.ts";

--- a/packages/probitas-client-sql/result.ts
+++ b/packages/probitas-client-sql/result.ts
@@ -1,0 +1,73 @@
+import { SqlRows } from "./rows.ts";
+
+/**
+ * Metadata for SQL query results.
+ */
+export interface SqlQueryResultMetadata {
+  /** Last inserted ID (for INSERT statements) */
+  readonly lastInsertId?: bigint | string;
+
+  /** Warning messages from the database */
+  readonly warnings?: readonly string[];
+}
+
+/**
+ * Options for creating a SqlQueryResult.
+ */
+export interface SqlQueryResultInit<T> {
+  /** Whether the query succeeded */
+  readonly ok: boolean;
+
+  /** The result rows */
+  readonly rows: readonly T[];
+
+  /** Number of affected rows (for INSERT/UPDATE/DELETE) */
+  readonly rowCount: number;
+
+  /** Query execution duration in milliseconds */
+  readonly duration: number;
+
+  /** Additional metadata */
+  readonly metadata: SqlQueryResultMetadata;
+}
+
+/**
+ * SQL query result with rows, metadata, and transformation methods.
+ */
+export class SqlQueryResult<T = Record<string, unknown>> {
+  readonly ok: boolean;
+  readonly rows: SqlRows<T>;
+  readonly rowCount: number;
+  readonly duration: number;
+  readonly metadata: SqlQueryResultMetadata;
+
+  constructor(init: SqlQueryResultInit<T>) {
+    this.ok = init.ok;
+    this.rows = new SqlRows(init.rows);
+    this.rowCount = init.rowCount;
+    this.duration = init.duration;
+    this.metadata = init.metadata;
+  }
+
+  /**
+   * Map rows to a new type.
+   */
+  map<U>(mapper: (row: T) => U): U[] {
+    const result: U[] = [];
+    for (const row of this.rows) {
+      result.push(mapper(row));
+    }
+    return result;
+  }
+
+  /**
+   * Create class instances from rows.
+   */
+  as<U>(ctor: new (row: T) => U): U[] {
+    const result: U[] = [];
+    for (const row of this.rows) {
+      result.push(new ctor(row));
+    }
+    return result;
+  }
+}

--- a/packages/probitas-client-sql/result_test.ts
+++ b/packages/probitas-client-sql/result_test.ts
@@ -1,0 +1,110 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { SqlQueryResult } from "./result.ts";
+import { SqlRows } from "./rows.ts";
+
+Deno.test("SqlQueryResult", async (t) => {
+  await t.step("creates with all properties", () => {
+    const result = new SqlQueryResult({
+      ok: true,
+      rows: [{ id: 1, name: "Alice" }],
+      rowCount: 1,
+      duration: 10,
+      metadata: { lastInsertId: 1n },
+    });
+
+    assertEquals(result.ok, true);
+    assertEquals(result.rowCount, 1);
+    assertEquals(result.duration, 10);
+    assertEquals(result.metadata.lastInsertId, 1n);
+  });
+
+  await t.step("rows is SqlRows instance", () => {
+    const result = new SqlQueryResult({
+      ok: true,
+      rows: [{ id: 1 }, { id: 2 }],
+      rowCount: 0,
+      duration: 5,
+      metadata: {},
+    });
+
+    assertInstanceOf(result.rows, SqlRows);
+    assertEquals(result.rows.length, 2);
+  });
+
+  await t.step("rows has first/last methods", () => {
+    const result = new SqlQueryResult({
+      ok: true,
+      rows: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      rowCount: 0,
+      duration: 5,
+      metadata: {},
+    });
+
+    assertEquals(result.rows.first(), { id: 1 });
+    assertEquals(result.rows.last(), { id: 3 });
+  });
+
+  await t.step("map() transforms rows", () => {
+    const result = new SqlQueryResult({
+      ok: true,
+      rows: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }],
+      rowCount: 0,
+      duration: 5,
+      metadata: {},
+    });
+
+    const names = result.map((row) => row.name);
+    assertEquals(names, ["Alice", "Bob"]);
+  });
+
+  await t.step("as() creates class instances", () => {
+    class User {
+      readonly id: number;
+      readonly displayName: string;
+
+      constructor(row: { id: number; name: string }) {
+        this.id = row.id;
+        this.displayName = `User: ${row.name}`;
+      }
+    }
+
+    const result = new SqlQueryResult({
+      ok: true,
+      rows: [{ id: 1, name: "Alice" }],
+      rowCount: 0,
+      duration: 5,
+      metadata: {},
+    });
+
+    const users = result.as(User);
+    assertEquals(users.length, 1);
+    assertInstanceOf(users[0], User);
+    assertEquals(users[0].id, 1);
+    assertEquals(users[0].displayName, "User: Alice");
+  });
+
+  await t.step("metadata defaults to empty object", () => {
+    const result = new SqlQueryResult({
+      ok: true,
+      rows: [],
+      rowCount: 0,
+      duration: 0,
+      metadata: {},
+    });
+
+    assertEquals(result.metadata.lastInsertId, undefined);
+    assertEquals(result.metadata.warnings, undefined);
+  });
+
+  await t.step("metadata with warnings", () => {
+    const result = new SqlQueryResult({
+      ok: true,
+      rows: [],
+      rowCount: 0,
+      duration: 0,
+      metadata: { warnings: ["truncation occurred"] },
+    });
+
+    assertEquals(result.metadata.warnings, ["truncation occurred"]);
+  });
+});

--- a/packages/probitas-client-sql/rows.ts
+++ b/packages/probitas-client-sql/rows.ts
@@ -1,0 +1,44 @@
+/**
+ * Row array with first/last helper methods.
+ * Implements ReadonlyArray<T> by extending Array<T>.
+ */
+export class SqlRows<T> extends Array<T> {
+  constructor(items: readonly T[]) {
+    super(...items);
+    Object.setPrototypeOf(this, SqlRows.prototype);
+  }
+
+  /**
+   * Get the first row, or undefined if empty.
+   */
+  first(): T | undefined {
+    return this[0];
+  }
+
+  /**
+   * Get the first row, or throw if empty.
+   */
+  firstOrThrow(): T {
+    if (this.length === 0) {
+      throw new Error("No rows found");
+    }
+    return this[0];
+  }
+
+  /**
+   * Get the last row, or undefined if empty.
+   */
+  last(): T | undefined {
+    return this[this.length - 1];
+  }
+
+  /**
+   * Get the last row, or throw if empty.
+   */
+  lastOrThrow(): T {
+    if (this.length === 0) {
+      throw new Error("No rows found");
+    }
+    return this[this.length - 1];
+  }
+}

--- a/packages/probitas-client-sql/rows_test.ts
+++ b/packages/probitas-client-sql/rows_test.ts
@@ -1,0 +1,93 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { SqlRows } from "./rows.ts";
+
+Deno.test("SqlRows", async (t) => {
+  await t.step("creates from array", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }]);
+    assertEquals(rows.length, 2);
+    assertEquals(rows[0], { id: 1 });
+    assertEquals(rows[1], { id: 2 });
+  });
+
+  await t.step("is iterable", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    const result: { id: number }[] = [];
+    for (const row of rows) {
+      result.push(row);
+    }
+    assertEquals(result, [{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  await t.step("supports spread operator", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }]);
+    const spread = [...rows];
+    assertEquals(spread, [{ id: 1 }, { id: 2 }]);
+  });
+
+  await t.step("supports find method", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    const found = rows.find((r) => r.id === 2);
+    assertEquals(found, { id: 2 });
+  });
+
+  await t.step("supports forEach method", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }]);
+    const result: number[] = [];
+    rows.forEach((r) => result.push(r.id));
+    assertEquals(result, [1, 2]);
+  });
+
+  await t.step("supports Array.from()", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }]);
+    const arr = Array.from(rows);
+    assertEquals(arr, [{ id: 1 }, { id: 2 }]);
+  });
+
+  await t.step("first() returns first element", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }]);
+    assertEquals(rows.first(), { id: 1 });
+  });
+
+  await t.step("first() returns undefined for empty array", () => {
+    const rows = new SqlRows<{ id: number }>([]);
+    assertEquals(rows.first(), undefined);
+  });
+
+  await t.step("firstOrThrow() returns first element", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }]);
+    assertEquals(rows.firstOrThrow(), { id: 1 });
+  });
+
+  await t.step("firstOrThrow() throws for empty array", () => {
+    const rows = new SqlRows<{ id: number }>([]);
+    assertThrows(
+      () => rows.firstOrThrow(),
+      Error,
+      "No rows found",
+    );
+  });
+
+  await t.step("last() returns last element", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    assertEquals(rows.last(), { id: 3 });
+  });
+
+  await t.step("last() returns undefined for empty array", () => {
+    const rows = new SqlRows<{ id: number }>([]);
+    assertEquals(rows.last(), undefined);
+  });
+
+  await t.step("lastOrThrow() returns last element", () => {
+    const rows = new SqlRows([{ id: 1 }, { id: 2 }]);
+    assertEquals(rows.lastOrThrow(), { id: 2 });
+  });
+
+  await t.step("lastOrThrow() throws for empty array", () => {
+    const rows = new SqlRows<{ id: number }>([]);
+    assertThrows(
+      () => rows.lastOrThrow(),
+      Error,
+      "No rows found",
+    );
+  });
+});

--- a/packages/probitas-client-sql/transaction.ts
+++ b/packages/probitas-client-sql/transaction.ts
@@ -1,0 +1,54 @@
+import type { SqlQueryResult } from "./result.ts";
+
+/**
+ * Transaction isolation level.
+ */
+export type SqlIsolationLevel =
+  | "read_uncommitted"
+  | "read_committed"
+  | "repeatable_read"
+  | "serializable";
+
+/**
+ * Options for starting a transaction.
+ */
+export interface SqlTransactionOptions {
+  /** Isolation level for the transaction */
+  readonly isolationLevel?: SqlIsolationLevel;
+}
+
+/**
+ * SQL transaction interface.
+ * Implementations should provide actual database-specific transaction handling.
+ */
+export interface SqlTransaction {
+  /**
+   * Execute a query within the transaction.
+   * @param sql - SQL query string
+   * @param params - Optional query parameters
+   */
+  query<T = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>>;
+
+  /**
+   * Execute a query and return the first row or undefined.
+   * @param sql - SQL query string
+   * @param params - Optional query parameters
+   */
+  queryOne<T = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined>;
+
+  /**
+   * Commit the transaction.
+   */
+  commit(): Promise<void>;
+
+  /**
+   * Rollback the transaction.
+   */
+  rollback(): Promise<void>;
+}


### PR DESCRIPTION
## Summary

- Add `@probitas/client-sql` package with SQL common types for all SQL client implementations
- Implement `SqlRows` class extending Array with `first()`/`last()` helper methods
- Implement `SqlQueryResult` with rows, metadata, and transformation methods (`map()`, `as()`)
- Implement `SqlTransaction` interface for transaction handling with isolation levels
- Implement `SqlError` hierarchy extending `ClientError`: `QuerySyntaxError`, `ConstraintError`, `DeadlockError`
- Implement `expectSqlQueryResult` fluent assertion API for query result validation

## Test plan

- [x] All unit tests pass (`deno task test`)
- [x] Type checking passes (`deno task check`)
- [x] Linting passes (`deno lint`)
- [x] Formatting verified (`deno fmt`)