### PR TITLE
feat: Implement @probitas/client-http package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,11 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      httpbin:
+        image: kennethreitz/httpbin
+        ports:
+          - 18080:80
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  httpbin:
+    image: kennethreitz/httpbin
+    ports:
+      - "18080:80"

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,7 @@
 {
   "workspace": [
-    "./packages/probitas-client"
+    "./packages/probitas-client",
+    "./packages/probitas-client-http"
   ],
   "exclude": [
     ".coverage/**",

--- a/deno.lock
+++ b/deno.lock
@@ -44,6 +44,13 @@
       "jsr:@std/path@^1.0.8",
       "jsr:@std/semver@^1.0.4",
       "jsr:@std/testing@^1.0.16"
-    ]
+    ],
+    "members": {
+      "packages/probitas-client-http": {
+        "dependencies": [
+          "jsr:@probitas/client@0"
+        ]
+      }
+    }
   }
 }

--- a/packages/probitas-client-http/client.ts
+++ b/packages/probitas-client-http/client.ts
@@ -1,0 +1,216 @@
+import type {
+  BodyInit,
+  HttpClient,
+  HttpClientConfig,
+  HttpOptions,
+  HttpResponse,
+  QueryValue,
+} from "./types.ts";
+import {
+  HttpBadRequestError,
+  HttpConflictError,
+  HttpError,
+  HttpForbiddenError,
+  HttpInternalServerError,
+  HttpNotFoundError,
+  HttpTooManyRequestsError,
+  HttpUnauthorizedError,
+} from "./errors.ts";
+import { createHttpResponse } from "./response.ts";
+
+/**
+ * Build URL with query parameters.
+ */
+function buildUrl(
+  baseUrl: string,
+  path: string,
+  query?: Record<string, QueryValue | QueryValue[]>,
+): string {
+  const url = new URL(path, baseUrl);
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (Array.isArray(value)) {
+        for (const v of value) {
+          url.searchParams.append(key, String(v));
+        }
+      } else {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  return url.toString();
+}
+
+/**
+ * Convert BodyInit to fetch-compatible body and headers.
+ */
+function prepareBody(
+  body?: BodyInit,
+): { body?: BodyInit; headers?: Record<string, string> } {
+  if (body === undefined) {
+    return {};
+  }
+
+  if (typeof body === "string" || body instanceof Uint8Array) {
+    return { body };
+  }
+
+  if (body instanceof FormData || body instanceof URLSearchParams) {
+    return { body };
+  }
+
+  // Plain object - serialize as JSON
+  return {
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  };
+}
+
+/**
+ * Merge headers from multiple sources.
+ */
+function mergeHeaders(
+  ...sources: (Record<string, string> | undefined)[]
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const source of sources) {
+    if (source) {
+      Object.assign(result, source);
+    }
+  }
+  return result;
+}
+
+/**
+ * Throw appropriate HttpError based on status code.
+ */
+function throwHttpError(response: HttpResponse): never {
+  const { status, statusText } = response;
+  const message = `HTTP ${status}: ${statusText}`;
+  const options = { response };
+
+  switch (status) {
+    case 400:
+      throw new HttpBadRequestError(message, options);
+    case 401:
+      throw new HttpUnauthorizedError(message, options);
+    case 403:
+      throw new HttpForbiddenError(message, options);
+    case 404:
+      throw new HttpNotFoundError(message, options);
+    case 409:
+      throw new HttpConflictError(message, options);
+    case 429:
+      throw new HttpTooManyRequestsError(message, options);
+    case 500:
+      throw new HttpInternalServerError(message, options);
+    default:
+      throw new HttpError(message, status, statusText, options);
+  }
+}
+
+/**
+ * HttpClient implementation.
+ */
+class HttpClientImpl implements HttpClient {
+  readonly config: HttpClientConfig;
+
+  constructor(config: HttpClientConfig) {
+    this.config = config;
+  }
+
+  get(path: string, options?: HttpOptions): Promise<HttpResponse> {
+    return this.#request("GET", path, undefined, options);
+  }
+
+  post(
+    path: string,
+    body?: BodyInit,
+    options?: HttpOptions,
+  ): Promise<HttpResponse> {
+    return this.#request("POST", path, body, options);
+  }
+
+  put(
+    path: string,
+    body?: BodyInit,
+    options?: HttpOptions,
+  ): Promise<HttpResponse> {
+    return this.#request("PUT", path, body, options);
+  }
+
+  patch(
+    path: string,
+    body?: BodyInit,
+    options?: HttpOptions,
+  ): Promise<HttpResponse> {
+    return this.#request("PATCH", path, body, options);
+  }
+
+  delete(path: string, options?: HttpOptions): Promise<HttpResponse> {
+    return this.#request("DELETE", path, undefined, options);
+  }
+
+  request(
+    method: string,
+    path: string,
+    options?: HttpOptions & { body?: BodyInit },
+  ): Promise<HttpResponse> {
+    return this.#request(method, path, options?.body, options);
+  }
+
+  async #request(
+    method: string,
+    path: string,
+    body?: BodyInit,
+    options?: HttpOptions,
+  ): Promise<HttpResponse> {
+    const url = buildUrl(this.config.baseUrl, path, options?.query);
+    const prepared = prepareBody(body);
+    const headers = mergeHeaders(
+      this.config.headers,
+      prepared.headers,
+      options?.headers,
+    );
+
+    const fetchFn = this.config.fetch ?? globalThis.fetch;
+    const startTime = performance.now();
+
+    const rawResponse = await fetchFn(url, {
+      method,
+      headers,
+      body: prepared.body as globalThis.BodyInit,
+      signal: options?.signal,
+    });
+
+    const duration = performance.now() - startTime;
+    const response = await createHttpResponse(rawResponse, duration);
+
+    // Determine whether to throw on error (request option > config > default true)
+    const shouldThrow = options?.throwOnError ?? this.config.throwOnError ??
+      true;
+
+    if (!response.ok && shouldThrow) {
+      throwHttpError(response);
+    }
+
+    return response;
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close();
+  }
+}
+
+/**
+ * Create a new HTTP client.
+ */
+export function createHttpClient(config: HttpClientConfig): HttpClient {
+  return new HttpClientImpl(config);
+}

--- a/packages/probitas-client-http/client_test.ts
+++ b/packages/probitas-client-http/client_test.ts
@@ -1,0 +1,519 @@
+import { assertEquals, assertInstanceOf, assertRejects } from "@std/assert";
+import { createHttpClient } from "./client.ts";
+import { HttpNotFoundError } from "./errors.ts";
+
+function createMockFetch(
+  handler: (req: Request) => Response | Promise<Response>,
+): typeof fetch {
+  return (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    return Promise.resolve(handler(request));
+  };
+}
+
+Deno.test("createHttpClient", async (t) => {
+  await t.step("returns HttpClient with config", () => {
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+    });
+    assertEquals(client.config.baseUrl, "http://localhost:3000");
+  });
+
+  await t.step("implements AsyncDisposable", async () => {
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+    });
+    // Check that client has Symbol.asyncDispose
+    assertEquals(typeof client[Symbol.asyncDispose], "function");
+    await client.close();
+  });
+});
+
+Deno.test("HttpClient.get", async (t) => {
+  await t.step("sends GET request to correct URL", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ id: 1 }), { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.get("/users/1");
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "GET");
+    assertEquals(capturedRequest?.url, "http://localhost:3000/users/1");
+  });
+
+  await t.step("returns HttpResponse with body", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response(JSON.stringify({ id: 1, name: "John" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    const response = await client.get("/users/1");
+    await client.close();
+
+    assertEquals(response.ok, true);
+    assertEquals(response.status, 200);
+    assertEquals(response.json(), { id: 1, name: "John" });
+  });
+
+  await t.step("includes query parameters", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response("[]", { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.get("/search", {
+      query: { q: "test", limit: 10, active: true },
+    });
+    await client.close();
+
+    const url = new URL(capturedRequest!.url);
+    assertEquals(url.searchParams.get("q"), "test");
+    assertEquals(url.searchParams.get("limit"), "10");
+    assertEquals(url.searchParams.get("active"), "true");
+  });
+
+  await t.step("supports array query parameters", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response("[]", { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.get("/filter", {
+      query: { tags: ["a", "b", "c"] },
+    });
+    await client.close();
+
+    const url = new URL(capturedRequest!.url);
+    assertEquals(url.searchParams.getAll("tags"), ["a", "b", "c"]);
+  });
+
+  await t.step("merges headers from config and options", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response("ok", { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      headers: { Authorization: "Bearer token123", "X-Custom": "from-config" },
+      fetch: mockFetch,
+    });
+
+    await client.get("/protected", {
+      headers: { "X-Request-Id": "abc123" },
+    });
+    await client.close();
+
+    assertEquals(
+      capturedRequest?.headers.get("Authorization"),
+      "Bearer token123",
+    );
+    assertEquals(capturedRequest?.headers.get("X-Custom"), "from-config");
+    assertEquals(capturedRequest?.headers.get("X-Request-Id"), "abc123");
+  });
+});
+
+Deno.test("HttpClient.post", async (t) => {
+  await t.step("sends POST request with JSON body", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ id: 1 }), { status: 201 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.post("/users", { name: "John", email: "john@example.com" });
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "POST");
+    assertEquals(
+      capturedRequest?.headers.get("Content-Type"),
+      "application/json",
+    );
+    const body = await capturedRequest?.json();
+    assertEquals(body, { name: "John", email: "john@example.com" });
+  });
+
+  await t.step("sends POST request with string body", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response("ok", { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.post("/text", "plain text body");
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "POST");
+    const body = await capturedRequest?.text();
+    assertEquals(body, "plain text body");
+  });
+
+  await t.step("sends POST request with Uint8Array body", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response("ok", { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    const binary = new Uint8Array([1, 2, 3, 4, 5]);
+    await client.post("/upload", binary);
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "POST");
+    const body = new Uint8Array(await capturedRequest!.arrayBuffer());
+    assertEquals(body, binary);
+  });
+
+  await t.step("sends POST request with URLSearchParams body", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response("ok", { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    const params = new URLSearchParams({ foo: "bar", baz: "qux" });
+    await client.post("/form", params);
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "POST");
+    const body = await capturedRequest?.text();
+    assertEquals(body, "foo=bar&baz=qux");
+  });
+});
+
+Deno.test("HttpClient.put", async (t) => {
+  await t.step("sends PUT request", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ id: 1 }), { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.put("/users/1", { name: "Updated" });
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "PUT");
+    assertEquals(capturedRequest?.url, "http://localhost:3000/users/1");
+  });
+});
+
+Deno.test("HttpClient.patch", async (t) => {
+  await t.step("sends PATCH request", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ id: 1 }), { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.patch("/users/1", { name: "Patched" });
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "PATCH");
+    assertEquals(capturedRequest?.url, "http://localhost:3000/users/1");
+  });
+});
+
+Deno.test("HttpClient.delete", async (t) => {
+  await t.step("sends DELETE request", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(null, { status: 204 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.delete("/users/1");
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "DELETE");
+    assertEquals(capturedRequest?.url, "http://localhost:3000/users/1");
+  });
+});
+
+Deno.test("HttpClient.request", async (t) => {
+  await t.step("sends request with arbitrary method", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response("ok", { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.request("OPTIONS", "/resource");
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "OPTIONS");
+    assertEquals(capturedRequest?.url, "http://localhost:3000/resource");
+  });
+
+  await t.step("supports body in request options", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response("ok", { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await client.request("PATCH", "/resource", { body: { data: "value" } });
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "PATCH");
+    const body = await capturedRequest?.json();
+    assertEquals(body, { data: "value" });
+  });
+});
+
+Deno.test("HttpClient error handling", async (t) => {
+  await t.step("throws HttpNotFoundError for 404", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response("Not Found", {
+        status: 404,
+        statusText: "Not Found",
+      });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    const error = await assertRejects(
+      () => client.get("/missing"),
+      HttpNotFoundError,
+    );
+    assertInstanceOf(error, HttpNotFoundError);
+    assertEquals(error.status, 404);
+    await client.close();
+  });
+});
+
+Deno.test("HttpClient response duration", async (t) => {
+  await t.step("includes duration in response", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response("ok", { status: 200 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    const response = await client.get("/test");
+    await client.close();
+
+    assertEquals(typeof response.duration, "number");
+    assertEquals(response.duration >= 0, true);
+  });
+});
+
+Deno.test("HttpClient throwOnError option", async (t) => {
+  await t.step("throws by default for 4xx response", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    await assertRejects(() => client.get("/missing"), HttpNotFoundError);
+    await client.close();
+  });
+
+  await t.step(
+    "returns response when throwOnError: false in request options",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response("Not Found", {
+          status: 404,
+          statusText: "Not Found",
+        });
+      });
+
+      const client = createHttpClient({
+        baseUrl: "http://localhost:3000",
+        fetch: mockFetch,
+      });
+
+      const response = await client.get("/missing", { throwOnError: false });
+      await client.close();
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 404);
+      assertEquals(response.statusText, "Not Found");
+    },
+  );
+
+  await t.step(
+    "returns response when throwOnError: false in client config",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response("Server Error", {
+          status: 500,
+          statusText: "Internal Server Error",
+        });
+      });
+
+      const client = createHttpClient({
+        baseUrl: "http://localhost:3000",
+        fetch: mockFetch,
+        throwOnError: false,
+      });
+
+      const response = await client.get("/error");
+      await client.close();
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 500);
+    },
+  );
+
+  await t.step(
+    "request option overrides client config (true overrides false)",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response("Not Found", { status: 404 });
+      });
+
+      const client = createHttpClient({
+        baseUrl: "http://localhost:3000",
+        fetch: mockFetch,
+        throwOnError: false,
+      });
+
+      await assertRejects(
+        () => client.get("/missing", { throwOnError: true }),
+        HttpNotFoundError,
+      );
+      await client.close();
+    },
+  );
+
+  await t.step(
+    "request option overrides client config (false overrides true)",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response("Not Found", { status: 404 });
+      });
+
+      const client = createHttpClient({
+        baseUrl: "http://localhost:3000",
+        fetch: mockFetch,
+        throwOnError: true,
+      });
+
+      const response = await client.get("/missing", { throwOnError: false });
+      await client.close();
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 404);
+    },
+  );
+
+  await t.step("works with POST method", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response("Bad Request", { status: 400 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    const response = await client.post("/data", { invalid: "data" }, {
+      throwOnError: false,
+    });
+    await client.close();
+
+    assertEquals(response.status, 400);
+  });
+
+  await t.step("works with request method", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response("Method Not Allowed", { status: 405 });
+    });
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:3000",
+      fetch: mockFetch,
+    });
+
+    const response = await client.request("CUSTOM", "/resource", {
+      throwOnError: false,
+    });
+    await client.close();
+
+    assertEquals(response.status, 405);
+  });
+});

--- a/packages/probitas-client-http/deno.json
+++ b/packages/probitas-client-http/deno.json
@@ -1,0 +1,11 @@
+{
+  "name": "@probitas/client-http",
+  "version": "0.0.0",
+  "exports": "./mod.ts",
+  "publish": {
+    "exclude": ["**/*_test.ts", "**/*_bench.ts"]
+  },
+  "imports": {
+    "@probitas/client": "jsr:@probitas/client@^0"
+  }
+}

--- a/packages/probitas-client-http/errors.ts
+++ b/packages/probitas-client-http/errors.ts
@@ -1,0 +1,130 @@
+import { ClientError } from "@probitas/client";
+import type { HttpResponse } from "./types.ts";
+
+/**
+ * Options for HttpError constructor.
+ */
+export interface HttpErrorOptions extends ErrorOptions {
+  /** Associated HTTP response */
+  readonly response?: HttpResponse;
+}
+
+/**
+ * Base HTTP error class.
+ */
+export class HttpError extends ClientError {
+  override readonly name: string = "HttpError";
+  override readonly kind = "http" as const;
+
+  /** HTTP status code */
+  readonly status: number;
+
+  /** HTTP status text */
+  readonly statusText: string;
+
+  /** Associated HTTP response (if available) */
+  readonly response?: HttpResponse;
+
+  constructor(
+    message: string,
+    status: number,
+    statusText: string,
+    options?: HttpErrorOptions,
+  ) {
+    super(message, "http", options);
+    this.status = status;
+    this.statusText = statusText;
+    this.response = options?.response;
+  }
+}
+
+/**
+ * HTTP 400 Bad Request error.
+ */
+export class HttpBadRequestError extends HttpError {
+  override readonly name = "HttpBadRequestError";
+  override readonly status = 400 as const;
+  override readonly statusText = "Bad Request";
+
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, 400, "Bad Request", options);
+  }
+}
+
+/**
+ * HTTP 401 Unauthorized error.
+ */
+export class HttpUnauthorizedError extends HttpError {
+  override readonly name = "HttpUnauthorizedError";
+  override readonly status = 401 as const;
+  override readonly statusText = "Unauthorized";
+
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, 401, "Unauthorized", options);
+  }
+}
+
+/**
+ * HTTP 403 Forbidden error.
+ */
+export class HttpForbiddenError extends HttpError {
+  override readonly name = "HttpForbiddenError";
+  override readonly status = 403 as const;
+  override readonly statusText = "Forbidden";
+
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, 403, "Forbidden", options);
+  }
+}
+
+/**
+ * HTTP 404 Not Found error.
+ */
+export class HttpNotFoundError extends HttpError {
+  override readonly name = "HttpNotFoundError";
+  override readonly status = 404 as const;
+  override readonly statusText = "Not Found";
+
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, 404, "Not Found", options);
+  }
+}
+
+/**
+ * HTTP 409 Conflict error.
+ */
+export class HttpConflictError extends HttpError {
+  override readonly name = "HttpConflictError";
+  override readonly status = 409 as const;
+  override readonly statusText = "Conflict";
+
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, 409, "Conflict", options);
+  }
+}
+
+/**
+ * HTTP 429 Too Many Requests error.
+ */
+export class HttpTooManyRequestsError extends HttpError {
+  override readonly name = "HttpTooManyRequestsError";
+  override readonly status = 429 as const;
+  override readonly statusText = "Too Many Requests";
+
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, 429, "Too Many Requests", options);
+  }
+}
+
+/**
+ * HTTP 500 Internal Server Error.
+ */
+export class HttpInternalServerError extends HttpError {
+  override readonly name = "HttpInternalServerError";
+  override readonly status = 500 as const;
+  override readonly statusText = "Internal Server Error";
+
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, 500, "Internal Server Error", options);
+  }
+}

--- a/packages/probitas-client-http/errors_test.ts
+++ b/packages/probitas-client-http/errors_test.ts
@@ -1,0 +1,161 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { ClientError } from "@probitas/client";
+import {
+  HttpBadRequestError,
+  HttpConflictError,
+  HttpError,
+  HttpForbiddenError,
+  HttpInternalServerError,
+  HttpNotFoundError,
+  HttpTooManyRequestsError,
+  HttpUnauthorizedError,
+} from "./errors.ts";
+
+Deno.test("HttpError", async (t) => {
+  await t.step("extends ClientError", () => {
+    const error = new HttpError("request failed", 500, "Internal Server Error");
+    assertInstanceOf(error, ClientError);
+    assertInstanceOf(error, HttpError);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new HttpError("request failed", 404, "Not Found");
+    assertEquals(error.name, "HttpError");
+    assertEquals(error.kind, "http");
+    assertEquals(error.message, "request failed");
+    assertEquals(error.status, 404);
+    assertEquals(error.statusText, "Not Found");
+    assertEquals(error.response, undefined);
+  });
+
+  await t.step("supports response property", () => {
+    const mockResponse = { status: 500 } as never;
+    const error = new HttpError(
+      "request failed",
+      500,
+      "Internal Server Error",
+      {
+        response: mockResponse,
+      },
+    );
+    assertEquals(error.response, mockResponse);
+  });
+
+  await t.step("supports cause option", () => {
+    const cause = new Error("network error");
+    const error = new HttpError(
+      "request failed",
+      500,
+      "Internal Server Error",
+      {
+        cause,
+      },
+    );
+    assertEquals(error.cause, cause);
+  });
+});
+
+Deno.test("HttpBadRequestError", async (t) => {
+  await t.step("extends HttpError", () => {
+    const error = new HttpBadRequestError("bad request");
+    assertInstanceOf(error, HttpError);
+    assertInstanceOf(error, HttpBadRequestError);
+  });
+
+  await t.step("has status 400", () => {
+    const error = new HttpBadRequestError("bad request");
+    assertEquals(error.name, "HttpBadRequestError");
+    assertEquals(error.status, 400);
+    assertEquals(error.statusText, "Bad Request");
+  });
+});
+
+Deno.test("HttpUnauthorizedError", async (t) => {
+  await t.step("extends HttpError", () => {
+    const error = new HttpUnauthorizedError("unauthorized");
+    assertInstanceOf(error, HttpError);
+    assertInstanceOf(error, HttpUnauthorizedError);
+  });
+
+  await t.step("has status 401", () => {
+    const error = new HttpUnauthorizedError("unauthorized");
+    assertEquals(error.name, "HttpUnauthorizedError");
+    assertEquals(error.status, 401);
+    assertEquals(error.statusText, "Unauthorized");
+  });
+});
+
+Deno.test("HttpForbiddenError", async (t) => {
+  await t.step("extends HttpError", () => {
+    const error = new HttpForbiddenError("forbidden");
+    assertInstanceOf(error, HttpError);
+    assertInstanceOf(error, HttpForbiddenError);
+  });
+
+  await t.step("has status 403", () => {
+    const error = new HttpForbiddenError("forbidden");
+    assertEquals(error.name, "HttpForbiddenError");
+    assertEquals(error.status, 403);
+    assertEquals(error.statusText, "Forbidden");
+  });
+});
+
+Deno.test("HttpNotFoundError", async (t) => {
+  await t.step("extends HttpError", () => {
+    const error = new HttpNotFoundError("not found");
+    assertInstanceOf(error, HttpError);
+    assertInstanceOf(error, HttpNotFoundError);
+  });
+
+  await t.step("has status 404", () => {
+    const error = new HttpNotFoundError("not found");
+    assertEquals(error.name, "HttpNotFoundError");
+    assertEquals(error.status, 404);
+    assertEquals(error.statusText, "Not Found");
+  });
+});
+
+Deno.test("HttpConflictError", async (t) => {
+  await t.step("extends HttpError", () => {
+    const error = new HttpConflictError("conflict");
+    assertInstanceOf(error, HttpError);
+    assertInstanceOf(error, HttpConflictError);
+  });
+
+  await t.step("has status 409", () => {
+    const error = new HttpConflictError("conflict");
+    assertEquals(error.name, "HttpConflictError");
+    assertEquals(error.status, 409);
+    assertEquals(error.statusText, "Conflict");
+  });
+});
+
+Deno.test("HttpTooManyRequestsError", async (t) => {
+  await t.step("extends HttpError", () => {
+    const error = new HttpTooManyRequestsError("rate limited");
+    assertInstanceOf(error, HttpError);
+    assertInstanceOf(error, HttpTooManyRequestsError);
+  });
+
+  await t.step("has status 429", () => {
+    const error = new HttpTooManyRequestsError("rate limited");
+    assertEquals(error.name, "HttpTooManyRequestsError");
+    assertEquals(error.status, 429);
+    assertEquals(error.statusText, "Too Many Requests");
+  });
+});
+
+Deno.test("HttpInternalServerError", async (t) => {
+  await t.step("extends HttpError", () => {
+    const error = new HttpInternalServerError("server error");
+    assertInstanceOf(error, HttpError);
+    assertInstanceOf(error, HttpInternalServerError);
+  });
+
+  await t.step("has status 500", () => {
+    const error = new HttpInternalServerError("server error");
+    assertEquals(error.name, "HttpInternalServerError");
+    assertEquals(error.status, 500);
+    assertEquals(error.statusText, "Internal Server Error");
+  });
+});

--- a/packages/probitas-client-http/expect.ts
+++ b/packages/probitas-client-http/expect.ts
@@ -1,0 +1,258 @@
+import type { HttpResponse } from "./types.ts";
+
+/**
+ * Fluent API for HTTP response validation.
+ */
+export interface HttpResponseExpectation {
+  /** Assert that response status is 200-299 */
+  ok(): this;
+
+  /** Assert that response status is not 200-299 */
+  notOk(): this;
+
+  /** Assert that response status matches expected code */
+  status(code: number): this;
+
+  /** Assert that response status is within range (inclusive) */
+  statusInRange(min: number, max: number): this;
+
+  /** Assert that header value matches expected string or regex */
+  header(name: string, expected: string | RegExp): this;
+
+  /** Assert that header exists */
+  headerExists(name: string): this;
+
+  /** Assert that Content-Type header matches expected string or regex */
+  contentType(expected: string | RegExp): this;
+
+  /** Assert that response body is null */
+  noContent(): this;
+
+  /** Assert that response body is not null */
+  hasContent(): this;
+
+  /** Assert that body contains given byte sequence */
+  bodyContains(subbody: Uint8Array): this;
+
+  /** Assert body using custom matcher function */
+  bodyMatch(matcher: (body: Uint8Array) => void): this;
+
+  /** Assert that text body contains substring */
+  textContains(substring: string): this;
+
+  /** Assert text body using custom matcher function */
+  textMatch(matcher: (text: string) => void): this;
+
+  /** Assert that JSON body contains expected properties */
+  jsonContains<T = unknown>(subset: Partial<T>): this;
+
+  /** Assert JSON body using custom matcher function */
+  jsonMatch<T = unknown>(matcher: (body: T) => void): this;
+
+  /** Assert that response duration is less than threshold (ms) */
+  durationLessThan(ms: number): this;
+}
+
+/**
+ * Check if an array contains a subarray.
+ */
+function containsSubarray(arr: Uint8Array, sub: Uint8Array): boolean {
+  if (sub.length === 0) return true;
+  if (sub.length > arr.length) return false;
+
+  outer: for (let i = 0; i <= arr.length - sub.length; i++) {
+    for (let j = 0; j < sub.length; j++) {
+      if (arr[i + j] !== sub[j]) continue outer;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check if an object contains all properties from subset.
+ */
+function containsProperties<T>(
+  obj: unknown,
+  subset: Partial<T>,
+): boolean {
+  if (typeof obj !== "object" || obj === null) return false;
+  if (typeof subset !== "object" || subset === null) return false;
+
+  for (const [key, value] of Object.entries(subset)) {
+    if (!(key in obj)) return false;
+    if ((obj as Record<string, unknown>)[key] !== value) return false;
+  }
+  return true;
+}
+
+/**
+ * HttpResponseExpectation implementation.
+ */
+class HttpResponseExpectationImpl implements HttpResponseExpectation {
+  readonly #response: HttpResponse;
+
+  constructor(response: HttpResponse) {
+    this.#response = response;
+  }
+
+  ok(): this {
+    if (!this.#response.ok) {
+      throw new Error(
+        `Expected ok response, got status ${this.#response.status}`,
+      );
+    }
+    return this;
+  }
+
+  notOk(): this {
+    if (this.#response.ok) {
+      throw new Error(
+        `Expected non-ok response, got status ${this.#response.status}`,
+      );
+    }
+    return this;
+  }
+
+  status(code: number): this {
+    if (this.#response.status !== code) {
+      throw new Error(
+        `Expected status ${code}, got ${this.#response.status}`,
+      );
+    }
+    return this;
+  }
+
+  statusInRange(min: number, max: number): this {
+    const { status } = this.#response;
+    if (status < min || status > max) {
+      throw new Error(
+        `Expected status in range ${min}-${max}, got ${status}`,
+      );
+    }
+    return this;
+  }
+
+  header(name: string, expected: string | RegExp): this {
+    const value = this.#response.headers.get(name);
+    if (value === null) {
+      throw new Error(`Header ${name} not found`);
+    }
+
+    if (typeof expected === "string") {
+      if (value !== expected) {
+        throw new Error(
+          `Expected header ${name} to be "${expected}", got "${value}"`,
+        );
+      }
+    } else {
+      if (!expected.test(value)) {
+        throw new Error(
+          `Expected header ${name} to match ${expected}, got "${value}"`,
+        );
+      }
+    }
+    return this;
+  }
+
+  headerExists(name: string): this {
+    if (!this.#response.headers.has(name)) {
+      throw new Error(`Header ${name} not found`);
+    }
+    return this;
+  }
+
+  contentType(expected: string | RegExp): this {
+    return this.header("Content-Type", expected);
+  }
+
+  noContent(): this {
+    if (this.#response.body !== null) {
+      throw new Error("Expected no content, but body exists");
+    }
+    return this;
+  }
+
+  hasContent(): this {
+    if (this.#response.body === null) {
+      throw new Error("Expected content, but body is null");
+    }
+    return this;
+  }
+
+  bodyContains(subbody: Uint8Array): this {
+    if (this.#response.body === null) {
+      throw new Error("Expected body to contain bytes, but body is null");
+    }
+    if (!containsSubarray(this.#response.body, subbody)) {
+      throw new Error("Body does not contain expected bytes");
+    }
+    return this;
+  }
+
+  bodyMatch(matcher: (body: Uint8Array) => void): this {
+    if (this.#response.body === null) {
+      throw new Error("Expected body for matching, but body is null");
+    }
+    matcher(this.#response.body);
+    return this;
+  }
+
+  textContains(substring: string): this {
+    const text = this.#response.text();
+    if (text === null) {
+      throw new Error("Expected text to contain substring, but body is null");
+    }
+    if (!text.includes(substring)) {
+      throw new Error(`Text does not contain "${substring}"`);
+    }
+    return this;
+  }
+
+  textMatch(matcher: (text: string) => void): this {
+    const text = this.#response.text();
+    if (text === null) {
+      throw new Error("Expected text for matching, but body is null");
+    }
+    matcher(text);
+    return this;
+  }
+
+  jsonContains<T = unknown>(subset: Partial<T>): this {
+    const json = this.#response.json();
+    if (json === null) {
+      throw new Error("Expected JSON to contain properties, but body is null");
+    }
+    if (!containsProperties(json, subset)) {
+      throw new Error("JSON does not contain expected properties");
+    }
+    return this;
+  }
+
+  jsonMatch<T = unknown>(matcher: (body: T) => void): this {
+    const json = this.#response.json<T>();
+    if (json === null) {
+      throw new Error("Expected JSON for matching, but body is null");
+    }
+    matcher(json);
+    return this;
+  }
+
+  durationLessThan(ms: number): this {
+    if (this.#response.duration >= ms) {
+      throw new Error(
+        `Expected duration < ${ms}ms, got ${this.#response.duration}ms`,
+      );
+    }
+    return this;
+  }
+}
+
+/**
+ * Create a fluent expectation chain for HTTP response validation.
+ */
+export function expectHttpResponse(
+  response: HttpResponse,
+): HttpResponseExpectation {
+  return new HttpResponseExpectationImpl(response);
+}

--- a/packages/probitas-client-http/expect_test.ts
+++ b/packages/probitas-client-http/expect_test.ts
@@ -1,0 +1,377 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { expectHttpResponse } from "./expect.ts";
+import type { HttpResponse } from "./types.ts";
+
+function createMockResponse(
+  overrides: Partial<HttpResponse> & { body?: Uint8Array | null } = {},
+): HttpResponse {
+  const hasBodyOverride = "body" in overrides;
+  const body = hasBodyOverride
+    ? overrides.body
+    : new TextEncoder().encode("test body");
+  const headers = overrides.headers ??
+    new Headers({ "Content-Type": "text/plain" });
+
+  return {
+    ok: overrides.ok ?? true,
+    status: overrides.status ?? 200,
+    statusText: overrides.statusText ?? "OK",
+    headers,
+    url: overrides.url ?? "http://localhost/test",
+    body: body ?? null,
+    duration: overrides.duration ?? 100,
+    raw: overrides.raw ?? new Response(),
+    arrayBuffer: () => {
+      if (!body) return null;
+      const buffer = new ArrayBuffer(body.byteLength);
+      new Uint8Array(buffer).set(body);
+      return buffer;
+    },
+    blob: () => {
+      if (!body) return null;
+      const buffer = new ArrayBuffer(body.byteLength);
+      new Uint8Array(buffer).set(body);
+      return new Blob([buffer]);
+    },
+    text: () => body ? new TextDecoder().decode(body) : null,
+    json: <T = unknown>() =>
+      body ? JSON.parse(new TextDecoder().decode(body)) as T : null,
+  };
+}
+
+Deno.test("expectHttpResponse.ok", async (t) => {
+  await t.step("passes for 2xx status", () => {
+    const response = createMockResponse({ ok: true, status: 200 });
+    expectHttpResponse(response).ok();
+  });
+
+  await t.step("throws for non-2xx status", () => {
+    const response = createMockResponse({ ok: false, status: 404 });
+    assertThrows(
+      () => expectHttpResponse(response).ok(),
+      Error,
+      "Expected ok response",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.notOk", async (t) => {
+  await t.step("passes for non-2xx status", () => {
+    const response = createMockResponse({ ok: false, status: 404 });
+    expectHttpResponse(response).notOk();
+  });
+
+  await t.step("throws for 2xx status", () => {
+    const response = createMockResponse({ ok: true, status: 200 });
+    assertThrows(
+      () => expectHttpResponse(response).notOk(),
+      Error,
+      "Expected non-ok response",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.status", async (t) => {
+  await t.step("passes when status matches", () => {
+    const response = createMockResponse({ status: 201 });
+    expectHttpResponse(response).status(201);
+  });
+
+  await t.step("throws when status does not match", () => {
+    const response = createMockResponse({ status: 200 });
+    assertThrows(
+      () => expectHttpResponse(response).status(201),
+      Error,
+      "Expected status 201, got 200",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.statusInRange", async (t) => {
+  await t.step("passes when status is in range", () => {
+    const response = createMockResponse({ status: 204 });
+    expectHttpResponse(response).statusInRange(200, 299);
+  });
+
+  await t.step("throws when status is out of range", () => {
+    const response = createMockResponse({ status: 404 });
+    assertThrows(
+      () => expectHttpResponse(response).statusInRange(200, 299),
+      Error,
+      "Expected status in range 200-299, got 404",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.header", async (t) => {
+  await t.step("passes when header matches string", () => {
+    const headers = new Headers({ "X-Custom": "value123" });
+    const response = createMockResponse({ headers });
+    expectHttpResponse(response).header("X-Custom", "value123");
+  });
+
+  await t.step("passes when header matches regex", () => {
+    const headers = new Headers({ "X-Custom": "value123" });
+    const response = createMockResponse({ headers });
+    expectHttpResponse(response).header("X-Custom", /value\d+/);
+  });
+
+  await t.step("throws when header does not match", () => {
+    const headers = new Headers({ "X-Custom": "value123" });
+    const response = createMockResponse({ headers });
+    assertThrows(
+      () => expectHttpResponse(response).header("X-Custom", "wrong"),
+      Error,
+      "Expected header X-Custom",
+    );
+  });
+
+  await t.step("throws when header is missing", () => {
+    const response = createMockResponse({ headers: new Headers() });
+    assertThrows(
+      () => expectHttpResponse(response).header("X-Missing", "value"),
+      Error,
+      "Header X-Missing not found",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.headerExists", async (t) => {
+  await t.step("passes when header exists", () => {
+    const headers = new Headers({ "X-Custom": "value" });
+    const response = createMockResponse({ headers });
+    expectHttpResponse(response).headerExists("X-Custom");
+  });
+
+  await t.step("throws when header is missing", () => {
+    const response = createMockResponse({ headers: new Headers() });
+    assertThrows(
+      () => expectHttpResponse(response).headerExists("X-Missing"),
+      Error,
+      "Header X-Missing not found",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.contentType", async (t) => {
+  await t.step("passes when content type matches string", () => {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    const response = createMockResponse({ headers });
+    expectHttpResponse(response).contentType("application/json");
+  });
+
+  await t.step("passes when content type matches regex", () => {
+    const headers = new Headers({
+      "Content-Type": "application/json; charset=utf-8",
+    });
+    const response = createMockResponse({ headers });
+    expectHttpResponse(response).contentType(/^application\/json/);
+  });
+
+  await t.step("throws when content type does not match", () => {
+    const headers = new Headers({ "Content-Type": "text/plain" });
+    const response = createMockResponse({ headers });
+    assertThrows(
+      () => expectHttpResponse(response).contentType("application/json"),
+      Error,
+      "Expected header Content-Type",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.noContent", async (t) => {
+  await t.step("passes when body is null", () => {
+    const response = createMockResponse({ body: null });
+    expectHttpResponse(response).noContent();
+  });
+
+  await t.step("throws when body exists", () => {
+    const response = createMockResponse({ body: new Uint8Array([1, 2, 3]) });
+    assertThrows(
+      () => expectHttpResponse(response).noContent(),
+      Error,
+      "Expected no content",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.hasContent", async (t) => {
+  await t.step("passes when body exists", () => {
+    const response = createMockResponse({ body: new Uint8Array([1, 2, 3]) });
+    expectHttpResponse(response).hasContent();
+  });
+
+  await t.step("throws when body is null", () => {
+    const response = createMockResponse({ body: null });
+    assertThrows(
+      () => expectHttpResponse(response).hasContent(),
+      Error,
+      "Expected content",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.bodyContains", async (t) => {
+  await t.step("passes when body contains subbody", () => {
+    const body = new Uint8Array([1, 2, 3, 4, 5]);
+    const response = createMockResponse({ body });
+    expectHttpResponse(response).bodyContains(new Uint8Array([2, 3, 4]));
+  });
+
+  await t.step("throws when body does not contain subbody", () => {
+    const body = new Uint8Array([1, 2, 3, 4, 5]);
+    const response = createMockResponse({ body });
+    assertThrows(
+      () =>
+        expectHttpResponse(response).bodyContains(new Uint8Array([6, 7, 8])),
+      Error,
+      "Body does not contain expected bytes",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.bodyMatch", async (t) => {
+  await t.step("calls matcher with body", () => {
+    const body = new Uint8Array([1, 2, 3]);
+    const response = createMockResponse({ body });
+    let called = false;
+    expectHttpResponse(response).bodyMatch((b) => {
+      called = true;
+      assertEquals(b, body);
+    });
+    assertEquals(called, true);
+  });
+
+  await t.step("throws if matcher throws", () => {
+    const response = createMockResponse({ body: new Uint8Array([1, 2, 3]) });
+    assertThrows(
+      () =>
+        expectHttpResponse(response).bodyMatch(() => {
+          throw new Error("custom error");
+        }),
+      Error,
+      "custom error",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.textContains", async (t) => {
+  await t.step("passes when text contains substring", () => {
+    const body = new TextEncoder().encode("hello world");
+    const response = createMockResponse({ body });
+    expectHttpResponse(response).textContains("world");
+  });
+
+  await t.step("throws when text does not contain substring", () => {
+    const body = new TextEncoder().encode("hello world");
+    const response = createMockResponse({ body });
+    assertThrows(
+      () => expectHttpResponse(response).textContains("foo"),
+      Error,
+      'Text does not contain "foo"',
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.textMatch", async (t) => {
+  await t.step("calls matcher with text", () => {
+    const body = new TextEncoder().encode("hello");
+    const response = createMockResponse({ body });
+    let capturedText = "";
+    expectHttpResponse(response).textMatch((text) => {
+      capturedText = text;
+    });
+    assertEquals(capturedText, "hello");
+  });
+});
+
+Deno.test("expectHttpResponse.jsonContains", async (t) => {
+  await t.step("passes when JSON contains subset", () => {
+    const body = new TextEncoder().encode(
+      JSON.stringify({ id: 1, name: "John", age: 30 }),
+    );
+    const response = createMockResponse({ body });
+    expectHttpResponse(response).jsonContains({ name: "John" });
+  });
+
+  await t.step("throws when JSON does not contain subset", () => {
+    const body = new TextEncoder().encode(
+      JSON.stringify({ id: 1, name: "John" }),
+    );
+    const response = createMockResponse({ body });
+    assertThrows(
+      () => expectHttpResponse(response).jsonContains({ name: "Jane" }),
+      Error,
+      "JSON does not contain expected properties",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse.jsonMatch", async (t) => {
+  await t.step("calls matcher with parsed JSON", () => {
+    const body = new TextEncoder().encode(
+      JSON.stringify({ id: 1, name: "John" }),
+    );
+    const response = createMockResponse({ body });
+    let capturedJson = null;
+    expectHttpResponse(response).jsonMatch((json) => {
+      capturedJson = json;
+    });
+    assertEquals(capturedJson, { id: 1, name: "John" });
+  });
+
+  await t.step("supports type parameter", () => {
+    interface User {
+      id: number;
+      name: string;
+    }
+    const body = new TextEncoder().encode(
+      JSON.stringify({ id: 1, name: "John" }),
+    );
+    const response = createMockResponse({ body });
+    expectHttpResponse(response).jsonMatch<User>((user) => {
+      assertEquals(user.id, 1);
+      assertEquals(user.name, "John");
+    });
+  });
+});
+
+Deno.test("expectHttpResponse.durationLessThan", async (t) => {
+  await t.step("passes when duration is less than threshold", () => {
+    const response = createMockResponse({ duration: 50 });
+    expectHttpResponse(response).durationLessThan(100);
+  });
+
+  await t.step("throws when duration exceeds threshold", () => {
+    const response = createMockResponse({ duration: 150 });
+    assertThrows(
+      () => expectHttpResponse(response).durationLessThan(100),
+      Error,
+      "Expected duration < 100ms, got 150ms",
+    );
+  });
+});
+
+Deno.test("expectHttpResponse chaining", async (t) => {
+  await t.step("allows chaining multiple assertions", () => {
+    const body = new TextEncoder().encode(
+      JSON.stringify({ id: 1, name: "John" }),
+    );
+    const headers = new Headers({ "Content-Type": "application/json" });
+    const response = createMockResponse({
+      ok: true,
+      status: 200,
+      headers,
+      body,
+      duration: 50,
+    });
+
+    expectHttpResponse(response)
+      .ok()
+      .status(200)
+      .contentType("application/json")
+      .hasContent()
+      .jsonContains({ name: "John" })
+      .durationLessThan(100);
+  });
+});

--- a/packages/probitas-client-http/integration_test.ts
+++ b/packages/probitas-client-http/integration_test.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration tests for @probitas/client-http using httpbin.
+ *
+ * Run with:
+ *   docker compose up -d
+ *   deno test -A packages/probitas-client-http/integration_test.ts
+ *   docker compose down
+ */
+
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import {
+  createHttpClient,
+  expectHttpResponse,
+  HttpNotFoundError,
+} from "./mod.ts";
+
+const HTTPBIN_URL = Deno.env.get("HTTPBIN_URL") ?? "http://localhost:18080";
+
+async function isHttpbinAvailable(): Promise<boolean> {
+  try {
+    const res = await fetch(`${HTTPBIN_URL}/get`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    // Consume the body to avoid resource leak
+    await res.body?.cancel();
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test({
+  name: "Integration: httpbin",
+  ignore: !(await isHttpbinAvailable()),
+  async fn(t) {
+    const client = createHttpClient({ baseUrl: HTTPBIN_URL });
+
+    await t.step("GET /get returns request info", async () => {
+      const res = await client.get("/get", {
+        query: { foo: "bar", num: 42 },
+        headers: { "X-Custom-Header": "test-value" },
+      });
+
+      expectHttpResponse(res)
+        .ok()
+        .status(200)
+        .contentType(/^application\/json/);
+
+      const json = res.json<{
+        args: Record<string, string>;
+        headers: Record<string, string>;
+        url: string;
+      }>();
+
+      assertEquals(json?.args.foo, "bar");
+      assertEquals(json?.args.num, "42");
+      assertEquals(json?.headers["X-Custom-Header"], "test-value");
+    });
+
+    await t.step("POST /post with JSON body", async () => {
+      const payload = { name: "John", email: "john@example.com" };
+      const res = await client.post("/post", payload);
+
+      expectHttpResponse(res)
+        .ok()
+        .status(200)
+        .contentType(/^application\/json/);
+
+      const json = res.json<{
+        json: typeof payload;
+        headers: Record<string, string>;
+      }>();
+
+      assertEquals(json?.json, payload);
+      assertEquals(json?.headers["Content-Type"], "application/json");
+    });
+
+    await t.step("POST /post with form data", async () => {
+      const params = new URLSearchParams({
+        username: "alice",
+        password: "secret",
+      });
+      const res = await client.post("/post", params);
+
+      expectHttpResponse(res).ok().status(200);
+
+      const json = res.json<{ form: Record<string, string> }>();
+      assertEquals(json?.form.username, "alice");
+      assertEquals(json?.form.password, "secret");
+    });
+
+    await t.step("PUT /put", async () => {
+      const res = await client.put("/put", { updated: true });
+
+      expectHttpResponse(res).ok().status(200);
+
+      const json = res.json<{ json: { updated: boolean } }>();
+      assertEquals(json?.json.updated, true);
+    });
+
+    await t.step("PATCH /patch", async () => {
+      const res = await client.patch("/patch", { patched: "value" });
+
+      expectHttpResponse(res).ok().status(200);
+
+      const json = res.json<{ json: { patched: string } }>();
+      assertEquals(json?.json.patched, "value");
+    });
+
+    await t.step("DELETE /delete", async () => {
+      const res = await client.delete("/delete");
+
+      expectHttpResponse(res).ok().status(200);
+    });
+
+    await t.step("GET /status/201 returns custom status", async () => {
+      const res = await client.request("GET", "/status/201");
+
+      expectHttpResponse(res).ok().status(201);
+    });
+
+    await t.step("GET /status/404 throws HttpNotFoundError", async () => {
+      try {
+        await client.get("/status/404");
+        throw new Error("Expected HttpNotFoundError");
+      } catch (error) {
+        assertInstanceOf(error, HttpNotFoundError);
+        assertEquals(error.status, 404);
+      }
+    });
+
+    await t.step("GET /headers returns request headers", async () => {
+      const res = await client.get("/headers", {
+        headers: {
+          "Accept": "application/json",
+        },
+      });
+
+      expectHttpResponse(res).ok();
+
+      const json = res.json<{ headers: Record<string, string> }>();
+      // Verify Accept header was sent (httpbin echoes back headers)
+      assertEquals(json?.headers["Accept"], "application/json");
+    });
+
+    await t.step("GET /delay/1 measures duration", async () => {
+      const res = await client.get("/delay/1");
+
+      expectHttpResponse(res).ok();
+      // Should take at least 1 second
+      assertEquals(
+        res.duration >= 1000,
+        true,
+        `Expected duration >= 1000ms, got ${res.duration}ms`,
+      );
+    });
+
+    await t.step("response body can be read multiple times", async () => {
+      const res = await client.get("/get");
+
+      // Read as text
+      const text1 = res.text();
+      const text2 = res.text();
+      assertEquals(text1, text2);
+
+      // Read as JSON
+      const json1 = res.json();
+      const json2 = res.json();
+      assertEquals(json1, json2);
+
+      // Body bytes are also available
+      assertInstanceOf(res.body, Uint8Array);
+    });
+
+    await t.step("uses default headers from config", async () => {
+      const clientWithHeaders = createHttpClient({
+        baseUrl: HTTPBIN_URL,
+        headers: {
+          "Authorization": "Bearer token123",
+          "X-Api-Version": "v1",
+        },
+      });
+
+      const res = await clientWithHeaders.get("/headers");
+      const json = res.json<{ headers: Record<string, string> }>();
+
+      assertEquals(json?.headers["Authorization"], "Bearer token123");
+      assertEquals(json?.headers["X-Api-Version"], "v1");
+
+      await clientWithHeaders.close();
+    });
+
+    await t.step("request headers override config headers", async () => {
+      const clientWithHeaders = createHttpClient({
+        baseUrl: HTTPBIN_URL,
+        headers: { "X-Header": "from-config" },
+      });
+
+      const res = await clientWithHeaders.get("/headers", {
+        headers: { "X-Header": "from-request" },
+      });
+      const json = res.json<{ headers: Record<string, string> }>();
+
+      assertEquals(json?.headers["X-Header"], "from-request");
+
+      await clientWithHeaders.close();
+    });
+
+    await client.close();
+  },
+});

--- a/packages/probitas-client-http/mod.ts
+++ b/packages/probitas-client-http/mod.ts
@@ -1,0 +1,54 @@
+/**
+ * @probitas/client-http - HTTP client for Probitas scenario testing framework.
+ *
+ * @example
+ * ```ts
+ * import { createHttpClient, expectHttpResponse } from "@probitas/client-http";
+ *
+ * const http = createHttpClient({ baseUrl: "http://localhost:3000" });
+ *
+ * const res = await http.get("/users/123");
+ * expectHttpResponse(res)
+ *   .ok()
+ *   .contentType("application/json")
+ *   .jsonContains({ name: "John" });
+ *
+ * const user = res.json<User>();
+ *
+ * await http.close();
+ * ```
+ *
+ * @module
+ */
+
+// Types (type-only exports for tree-shaking)
+export type {
+  BodyInit,
+  HttpClient,
+  HttpClientConfig,
+  HttpOptions,
+  HttpResponse,
+  QueryValue,
+} from "./types.ts";
+
+// Errors
+export {
+  HttpBadRequestError,
+  HttpConflictError,
+  HttpError,
+  type HttpErrorOptions,
+  HttpForbiddenError,
+  HttpInternalServerError,
+  HttpNotFoundError,
+  HttpTooManyRequestsError,
+  HttpUnauthorizedError,
+} from "./errors.ts";
+
+// Client
+export { createHttpClient } from "./client.ts";
+
+// Response (internal, but exported for testing/advanced use)
+export { createHttpResponse } from "./response.ts";
+
+// Expectations
+export { expectHttpResponse, type HttpResponseExpectation } from "./expect.ts";

--- a/packages/probitas-client-http/response.ts
+++ b/packages/probitas-client-http/response.ts
@@ -1,0 +1,96 @@
+import type { HttpResponse } from "./types.ts";
+
+/**
+ * Implementation of HttpResponse with pre-loaded body.
+ */
+class HttpResponseImpl implements HttpResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly headers: Headers;
+  readonly url: string;
+  readonly body: Uint8Array | null;
+  readonly duration: number;
+  readonly raw: globalThis.Response;
+
+  #textCache: string | null | undefined;
+  #jsonCache: unknown | undefined;
+  #jsonParsed = false;
+
+  constructor(
+    raw: globalThis.Response,
+    body: Uint8Array | null,
+    duration: number,
+  ) {
+    this.ok = raw.ok;
+    this.status = raw.status;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+    this.url = raw.url;
+    this.body = body;
+    this.duration = duration;
+    this.raw = raw;
+  }
+
+  arrayBuffer(): ArrayBuffer | null {
+    if (this.body === null) {
+      return null;
+    }
+    // Create a new ArrayBuffer copy to ensure correct type
+    const buffer = new ArrayBuffer(this.body.byteLength);
+    new Uint8Array(buffer).set(this.body);
+    return buffer;
+  }
+
+  blob(): Blob | null {
+    if (this.body === null) {
+      return null;
+    }
+    const contentType = this.headers.get("content-type") ?? "";
+    // Use arrayBuffer() to get a properly typed buffer
+    return new Blob([this.arrayBuffer()!], { type: contentType });
+  }
+
+  text(): string | null {
+    if (this.body === null) {
+      return null;
+    }
+    if (this.#textCache === undefined) {
+      this.#textCache = new TextDecoder().decode(this.body);
+    }
+    return this.#textCache;
+  }
+
+  json<T = unknown>(): T | null {
+    if (this.body === null) {
+      return null;
+    }
+    if (!this.#jsonParsed) {
+      const textValue = this.text();
+      this.#jsonCache = textValue !== null ? JSON.parse(textValue) : null;
+      this.#jsonParsed = true;
+    }
+    return this.#jsonCache as T;
+  }
+}
+
+/**
+ * Create HttpResponse from raw Response.
+ *
+ * Consumes the response body and creates a reusable HttpResponse.
+ */
+export async function createHttpResponse(
+  raw: globalThis.Response,
+  duration: number,
+): Promise<HttpResponse> {
+  let body: Uint8Array | null = null;
+
+  if (raw.body !== null) {
+    const arrayBuffer = await raw.arrayBuffer();
+    if (arrayBuffer.byteLength > 0) {
+      body = new Uint8Array(arrayBuffer);
+    }
+  }
+
+  return new HttpResponseImpl(raw, body, duration);
+}

--- a/packages/probitas-client-http/response_test.ts
+++ b/packages/probitas-client-http/response_test.ts
@@ -1,0 +1,168 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { createHttpResponse } from "./response.ts";
+
+Deno.test("createHttpResponse", async (t) => {
+  await t.step("creates HttpResponse from Response with body", async () => {
+    const raw = new Response(JSON.stringify({ name: "test" }), {
+      status: 200,
+      statusText: "OK",
+      headers: { "Content-Type": "application/json" },
+    });
+    const duration = 100;
+
+    const response = await createHttpResponse(raw, duration);
+
+    assertEquals(response.ok, true);
+    assertEquals(response.status, 200);
+    assertEquals(response.statusText, "OK");
+    assertEquals(response.headers.get("content-type"), "application/json");
+    assertEquals(response.duration, 100);
+    assertInstanceOf(response.body, Uint8Array);
+  });
+
+  await t.step("creates HttpResponse from Response without body", async () => {
+    const raw = new Response(null, {
+      status: 204,
+      statusText: "No Content",
+    });
+    const duration = 50;
+
+    const response = await createHttpResponse(raw, duration);
+
+    assertEquals(response.ok, true);
+    assertEquals(response.status, 204);
+    assertEquals(response.statusText, "No Content");
+    assertEquals(response.body, null);
+    assertEquals(response.duration, 50);
+  });
+
+  await t.step("text() returns body as string", async () => {
+    const raw = new Response("hello world", { status: 200 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.text(), "hello world");
+  });
+
+  await t.step("text() returns null when no body", async () => {
+    const raw = new Response(null, { status: 204 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.text(), null);
+  });
+
+  await t.step("text() can be called multiple times", async () => {
+    const raw = new Response("hello", { status: 200 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.text(), "hello");
+    assertEquals(response.text(), "hello");
+    assertEquals(response.text(), "hello");
+  });
+
+  await t.step("json() returns parsed JSON", async () => {
+    const data = { name: "John", age: 30 };
+    const raw = new Response(JSON.stringify(data), { status: 200 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.json(), data);
+  });
+
+  await t.step("json() returns null when no body", async () => {
+    const raw = new Response(null, { status: 204 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.json(), null);
+  });
+
+  await t.step("json() can be called multiple times", async () => {
+    const data = { id: 1 };
+    const raw = new Response(JSON.stringify(data), { status: 200 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.json(), data);
+    assertEquals(response.json(), data);
+    assertEquals(response.json(), data);
+  });
+
+  await t.step("json() supports generic type hint", async () => {
+    interface User {
+      id: number;
+      name: string;
+    }
+    const raw = new Response(JSON.stringify({ id: 1, name: "Alice" }), {
+      status: 200,
+    });
+    const response = await createHttpResponse(raw, 10);
+
+    const user = response.json<User>();
+    assertEquals(user?.id, 1);
+    assertEquals(user?.name, "Alice");
+  });
+
+  await t.step("arrayBuffer() returns ArrayBuffer", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const raw = new Response(bytes, { status: 200 });
+    const response = await createHttpResponse(raw, 10);
+
+    const buffer = response.arrayBuffer();
+    assertInstanceOf(buffer, ArrayBuffer);
+    assertEquals(new Uint8Array(buffer!), bytes);
+  });
+
+  await t.step("arrayBuffer() returns null when no body", async () => {
+    const raw = new Response(null, { status: 204 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.arrayBuffer(), null);
+  });
+
+  await t.step("blob() returns Blob", async () => {
+    const raw = new Response("hello", {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    });
+    const response = await createHttpResponse(raw, 10);
+
+    const blob = response.blob();
+    assertInstanceOf(blob, Blob);
+    assertEquals(await blob!.text(), "hello");
+  });
+
+  await t.step("blob() returns null when no body", async () => {
+    const raw = new Response(null, { status: 204 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.blob(), null);
+  });
+
+  await t.step("raw property returns original Response", async () => {
+    const original = new Response("test", { status: 200 });
+    const response = await createHttpResponse(original, 10);
+
+    assertEquals(response.raw, original);
+  });
+
+  await t.step("url property reflects Response url", async () => {
+    const raw = new Response("test", { status: 200 });
+    Object.defineProperty(raw, "url", { value: "http://example.com/api" });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.url, "http://example.com/api");
+  });
+
+  await t.step("ok is false for 4xx status", async () => {
+    const raw = new Response("not found", { status: 404 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.ok, false);
+    assertEquals(response.status, 404);
+  });
+
+  await t.step("ok is false for 5xx status", async () => {
+    const raw = new Response("server error", { status: 500 });
+    const response = await createHttpResponse(raw, 10);
+
+    assertEquals(response.ok, false);
+    assertEquals(response.status, 500);
+  });
+});

--- a/packages/probitas-client-http/types.ts
+++ b/packages/probitas-client-http/types.ts
@@ -1,0 +1,153 @@
+import type { CommonOptions } from "@probitas/client";
+
+/**
+ * HTTP response with pre-loaded body for synchronous access.
+ *
+ * Wraps Web standard Response, allowing body to be read synchronously
+ * and multiple times (unlike the streaming-based standard Response).
+ */
+export interface HttpResponse {
+  // --- Web standard Response compatible properties ---
+
+  /** Whether the response was successful (status 200-299) */
+  readonly ok: boolean;
+
+  /** HTTP status code */
+  readonly status: number;
+
+  /** HTTP status text */
+  readonly statusText: string;
+
+  /** Response headers */
+  readonly headers: Headers;
+
+  /** Request URL */
+  readonly url: string;
+
+  // --- Body access (synchronous, reusable, null if no body) ---
+
+  /** Response body as raw bytes (null if no body) */
+  readonly body: Uint8Array | null;
+
+  /** Get body as ArrayBuffer (null if no body) */
+  arrayBuffer(): ArrayBuffer | null;
+
+  /** Get body as Blob (null if no body) */
+  blob(): Blob | null;
+
+  /** Get body as text (null if no body) */
+  text(): string | null;
+
+  /**
+   * Get body as parsed JSON (null if no body)
+   * @template T - defaults to any for test convenience
+   */
+  json<T = unknown>(): T | null;
+
+  // --- Additional properties ---
+
+  /** Response time in milliseconds */
+  readonly duration: number;
+
+  /** Raw Web standard Response (for streaming or special cases) */
+  readonly raw: globalThis.Response;
+}
+
+/**
+ * Query parameter value type.
+ */
+export type QueryValue = string | number | boolean;
+
+/**
+ * Request body type.
+ */
+export type BodyInit =
+  | string
+  | Uint8Array
+  | Record<string, unknown>
+  | FormData
+  | URLSearchParams;
+
+/**
+ * Options for individual HTTP requests.
+ */
+export interface HttpOptions extends CommonOptions {
+  /** Query parameters (arrays for multi-value params) */
+  readonly query?: Record<string, QueryValue | QueryValue[]>;
+
+  /** Additional request headers */
+  readonly headers?: Record<string, string>;
+
+  /**
+   * Whether to throw HttpError for non-2xx responses.
+   * When false, non-2xx responses are returned as HttpResponse.
+   * @default true (inherited from client config if not specified)
+   */
+  readonly throwOnError?: boolean;
+}
+
+/**
+ * HTTP client configuration.
+ */
+export interface HttpClientConfig extends CommonOptions {
+  /** Base URL for all requests */
+  readonly baseUrl: string;
+
+  /** Default headers for all requests */
+  readonly headers?: Record<string, string>;
+
+  /** Custom fetch implementation (for testing/mocking) */
+  readonly fetch?: typeof fetch;
+
+  /**
+   * Whether to throw HttpError for non-2xx responses.
+   * Can be overridden per-request via HttpOptions.
+   * @default true
+   */
+  readonly throwOnError?: boolean;
+}
+
+/**
+ * HTTP client interface.
+ */
+export interface HttpClient extends AsyncDisposable {
+  /** Client configuration */
+  readonly config: HttpClientConfig;
+
+  /** Send GET request */
+  get(path: string, options?: HttpOptions): Promise<HttpResponse>;
+
+  /** Send POST request */
+  post(
+    path: string,
+    body?: BodyInit,
+    options?: HttpOptions,
+  ): Promise<HttpResponse>;
+
+  /** Send PUT request */
+  put(
+    path: string,
+    body?: BodyInit,
+    options?: HttpOptions,
+  ): Promise<HttpResponse>;
+
+  /** Send PATCH request */
+  patch(
+    path: string,
+    body?: BodyInit,
+    options?: HttpOptions,
+  ): Promise<HttpResponse>;
+
+  /** Send DELETE request */
+  delete(path: string, options?: HttpOptions): Promise<HttpResponse>;
+
+  /** Send request with arbitrary method */
+  request(
+    method: string,
+    path: string,
+    options?: HttpOptions & { body?: BodyInit },
+  ): Promise<HttpResponse>;
+
+  /** Close the client and release resources */
+  close(): Promise<void>;
+}


### PR DESCRIPTION
## Summary

- Add `@probitas/client-http` package with full HTTP client implementation
- Implement `HttpResponse` with pre-loaded body for synchronous, reusable access
- Add `throwOnError` option to control error throwing at client/request level
- Include `expectHttpResponse()` fluent API for test assertions
- Set up Docker Compose with httpbin for integration testing

## Features

### HttpClient
- `get`, `post`, `put`, `patch`, `delete`, `request` methods
- Query parameter support (including arrays)
- Header merging (config + request)
- Custom fetch injection for testing

### HttpResponse
- Synchronous body access: `text()`, `json<T>()`, `arrayBuffer()`, `blob()`
- Reusable (can read multiple times unlike standard Response)
- `duration` property for performance measurement

### HttpError Hierarchy
- `HttpBadRequestError` (400)
- `HttpUnauthorizedError` (401)
- `HttpForbiddenError` (403)
- `HttpNotFoundError` (404)
- `HttpConflictError` (409)
- `HttpTooManyRequestsError` (429)
- `HttpInternalServerError` (500)

### throwOnError Option
- Default: `true` (throws on non-2xx)
- Configurable at client level and per-request
- Request option overrides client config

## Test plan

- [x] Unit tests pass (40 tests, 106 steps)
- [x] Type check passes
- [x] Lint passes
- [ ] Integration tests with httpbin (`docker compose up -d && deno task test`)