### PR TITLE
feat: Implement @probitas/client-graphql package

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,3 +9,9 @@ services:
     image: romk/grpc-helloworld-reflection
     ports:
       - "50051:50051"
+
+  # GraphQL server for integration testing
+  graphql:
+    image: npalm/graphql-java-demo
+    ports:
+      - "14000:8080"

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,7 @@
 {
   "workspace": [
     "./packages/probitas-client",
+    "./packages/probitas-client-graphql",
     "./packages/probitas-client-grpc",
     "./packages/probitas-client-http",
     "./packages/probitas-client-sql"
@@ -22,6 +23,7 @@
     "@std/semver": "jsr:@std/semver@^1.0.4",
     "@std/testing": "jsr:@std/testing@^1.0.16",
     "jsr:@probitas/client@^0": "./packages/probitas-client/mod.ts",
+    "jsr:@probitas/client-graphql@^0": "./packages/probitas-client-graphql/mod.ts",
     "jsr:@probitas/client-grpc@^0": "./packages/probitas-client-grpc/mod.ts",
     "jsr:@probitas/client-http@^0": "./packages/probitas-client-http/mod.ts",
     "jsr:@probitas/client-sql@^0": "./packages/probitas-client-sql/mod.ts"

--- a/deno.lock
+++ b/deno.lock
@@ -1,10 +1,9 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@core/asyncutil@*": "1.2.0",
+    "jsr:@cspotcode/outdent@0.8": "0.8.0",
     "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/assert@^1.0.16": "1.0.16",
-    "jsr:@std/async@*": "1.0.15",
     "jsr:@std/async@^1.0.15": "1.0.15",
     "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/fs@^1.0.19": "1.0.20",
@@ -22,8 +21,8 @@
     "npm:grpc-reflection-js@0.3": "0.3.0_@grpc+grpc-js@1.12.6"
   },
   "jsr": {
-    "@core/asyncutil@1.2.0": {
-      "integrity": "9967f15190c60df032c13f72ce5ac73d185c34f31c53dc918d8800025854c118"
+    "@cspotcode/outdent@0.8.0": {
+      "integrity": "bbb3dea1443b4191a091644dfeaf3f182cca83e9003d211c50786c21792695f6"
     },
     "@std/assert@1.0.16": {
       "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
@@ -68,7 +67,7 @@
       "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
       "dependencies": [
         "jsr:@std/assert@^1.0.15",
-        "jsr:@std/async@^1.0.15",
+        "jsr:@std/async",
         "jsr:@std/data-structures",
         "jsr:@std/fs",
         "jsr:@std/internal",
@@ -293,6 +292,12 @@
       "jsr:@std/testing@^1.0.16"
     ],
     "members": {
+      "packages/probitas-client-graphql": {
+        "dependencies": [
+          "jsr:@cspotcode/outdent@0.8",
+          "jsr:@probitas/client@0"
+        ]
+      },
       "packages/probitas-client-grpc": {
         "dependencies": [
           "jsr:@probitas/client@0",

--- a/packages/probitas-client-graphql/client.ts
+++ b/packages/probitas-client-graphql/client.ts
@@ -1,0 +1,155 @@
+import type {
+  GraphqlClient,
+  GraphqlClientConfig,
+  GraphqlErrorItem,
+  GraphqlOptions,
+  GraphqlResponse,
+} from "./types.ts";
+import { GraphqlExecutionError, GraphqlNetworkError } from "./errors.ts";
+import { createGraphqlResponse } from "./response.ts";
+
+/**
+ * Merge headers from multiple sources.
+ * Later sources override earlier ones.
+ */
+function mergeHeaders(
+  ...sources: (Record<string, string> | undefined)[]
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const source of sources) {
+    if (source) {
+      Object.assign(result, source);
+    }
+  }
+  return result;
+}
+
+/**
+ * GraphQL response structure from server.
+ */
+interface GraphqlResponseBody<T> {
+  data?: T | null;
+  errors?: GraphqlErrorItem[];
+  extensions?: Record<string, unknown>;
+}
+
+/**
+ * GraphqlClient implementation.
+ */
+class GraphqlClientImpl implements GraphqlClient {
+  readonly config: GraphqlClientConfig;
+
+  constructor(config: GraphqlClientConfig) {
+    this.config = config;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  query<TData = any, TVariables = Record<string, any>>(
+    query: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): Promise<GraphqlResponse<TData>> {
+    return this.execute<TData, TVariables>(query, variables, options);
+  }
+
+  // deno-lint-ignore no-explicit-any
+  mutation<TData = any, TVariables = Record<string, any>>(
+    mutation: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): Promise<GraphqlResponse<TData>> {
+    return this.execute<TData, TVariables>(mutation, variables, options);
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async execute<TData = any, TVariables = Record<string, any>>(
+    document: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): Promise<GraphqlResponse<TData>> {
+    const headers = mergeHeaders(
+      { "Content-Type": "application/json" },
+      this.config.headers,
+      options?.headers,
+    );
+
+    const body = JSON.stringify({
+      query: document,
+      variables: variables ?? undefined,
+      operationName: options?.operationName,
+    });
+
+    const fetchFn = this.config.fetch ?? globalThis.fetch;
+    const startTime = performance.now();
+
+    let rawResponse: Response;
+    try {
+      rawResponse = await fetchFn(this.config.endpoint, {
+        method: "POST",
+        headers,
+        body,
+        signal: options?.signal,
+      });
+    } catch (error) {
+      throw new GraphqlNetworkError(
+        `Network error: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+
+    const duration = performance.now() - startTime;
+
+    if (!rawResponse.ok) {
+      throw new GraphqlNetworkError(
+        `HTTP ${rawResponse.status}: ${rawResponse.statusText}`,
+      );
+    }
+
+    let responseBody: GraphqlResponseBody<TData>;
+    try {
+      responseBody = await rawResponse.json();
+    } catch (error) {
+      throw new GraphqlNetworkError("Failed to parse response JSON", {
+        cause: error,
+      });
+    }
+
+    const response = createGraphqlResponse<TData>({
+      data: responseBody.data ?? null,
+      errors: responseBody.errors ?? null,
+      extensions: responseBody.extensions,
+      duration,
+      status: rawResponse.status,
+      raw: rawResponse,
+    });
+
+    // Determine whether to throw on errors (request option > config > default true)
+    const shouldThrow = options?.throwOnError ?? this.config.throwOnError ??
+      true;
+
+    if (!response.ok && shouldThrow && response.errors) {
+      throw new GraphqlExecutionError(response.errors, { response });
+    }
+
+    return response;
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close();
+  }
+}
+
+/**
+ * Create a new GraphQL client.
+ */
+export function createGraphqlClient(
+  config: GraphqlClientConfig,
+): GraphqlClient {
+  return new GraphqlClientImpl(config);
+}

--- a/packages/probitas-client-graphql/client_test.ts
+++ b/packages/probitas-client-graphql/client_test.ts
@@ -1,0 +1,524 @@
+import { assertEquals, assertInstanceOf, assertRejects } from "@std/assert";
+import { createGraphqlClient } from "./client.ts";
+import { GraphqlExecutionError, GraphqlNetworkError } from "./errors.ts";
+
+function createMockFetch(
+  handler: (req: Request) => Response | Promise<Response>,
+): typeof fetch {
+  return (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    return Promise.resolve(handler(request));
+  };
+}
+
+Deno.test("createGraphqlClient", async (t) => {
+  await t.step("returns GraphqlClient with config", () => {
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+    });
+    assertEquals(client.config.endpoint, "http://localhost:4000/graphql");
+  });
+
+  await t.step("implements AsyncDisposable", async () => {
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+    });
+    assertEquals(typeof client[Symbol.asyncDispose], "function");
+    await client.close();
+  });
+});
+
+Deno.test("GraphqlClient.query", async (t) => {
+  await t.step("sends POST request with query", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ data: { user: { id: 1 } } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    await client.query("query { user { id } }");
+    await client.close();
+
+    assertEquals(capturedRequest?.method, "POST");
+    assertEquals(capturedRequest?.url, "http://localhost:4000/graphql");
+    const body = await capturedRequest?.json();
+    assertEquals(body.query, "query { user { id } }");
+  });
+
+  await t.step("includes variables in request", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ data: { user: { id: 1 } } }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    await client.query("query GetUser($id: ID!) { user(id: $id) { id } }", {
+      id: "123",
+    });
+    await client.close();
+
+    const body = await capturedRequest?.json();
+    assertEquals(body.variables, { id: "123" });
+  });
+
+  await t.step("includes operationName when provided", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ data: null }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    await client.query(
+      "query GetUser { user { id } } query GetUsers { users { id } }",
+      undefined,
+      { operationName: "GetUser" },
+    );
+    await client.close();
+
+    const body = await capturedRequest?.json();
+    assertEquals(body.operationName, "GetUser");
+  });
+
+  await t.step("returns GraphqlResponse with data", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response(
+        JSON.stringify({ data: { user: { id: 1, name: "John" } } }),
+      );
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    const response = await client.query("query { user { id name } }");
+    await client.close();
+
+    assertEquals(response.ok, true);
+    assertEquals(response.data, { user: { id: 1, name: "John" } });
+    assertEquals(response.errors, null);
+  });
+
+  await t.step(
+    "throws GraphqlExecutionError on errors by default",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response(
+          JSON.stringify({
+            data: null,
+            errors: [{ message: "User not found" }],
+          }),
+        );
+      });
+
+      const client = createGraphqlClient({
+        endpoint: "http://localhost:4000/graphql",
+        fetch: mockFetch,
+      });
+
+      const error = await assertRejects(
+        () => client.query("query { user { id } }"),
+        GraphqlExecutionError,
+      );
+      assertInstanceOf(error, GraphqlExecutionError);
+      assertEquals(error.errors[0].message, "User not found");
+      await client.close();
+    },
+  );
+
+  await t.step(
+    "returns response with errors when throwOnError: false in config",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response(
+          JSON.stringify({
+            data: null,
+            errors: [{ message: "User not found" }],
+          }),
+        );
+      });
+
+      const client = createGraphqlClient({
+        endpoint: "http://localhost:4000/graphql",
+        fetch: mockFetch,
+        throwOnError: false,
+      });
+
+      const response = await client.query("query { user { id } }");
+      await client.close();
+
+      assertEquals(response.ok, false);
+      assertEquals(response.errors?.length, 1);
+      assertEquals(response.errors?.[0].message, "User not found");
+    },
+  );
+
+  await t.step(
+    "returns response with errors when throwOnError: false in options",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response(
+          JSON.stringify({
+            data: null,
+            errors: [{ message: "Error" }],
+          }),
+        );
+      });
+
+      const client = createGraphqlClient({
+        endpoint: "http://localhost:4000/graphql",
+        fetch: mockFetch,
+      });
+
+      const response = await client.query("query { test }", undefined, {
+        throwOnError: false,
+      });
+      await client.close();
+
+      assertEquals(response.ok, false);
+    },
+  );
+
+  await t.step(
+    "options throwOnError overrides config (true overrides false)",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response(
+          JSON.stringify({
+            data: null,
+            errors: [{ message: "Error" }],
+          }),
+        );
+      });
+
+      const client = createGraphqlClient({
+        endpoint: "http://localhost:4000/graphql",
+        fetch: mockFetch,
+        throwOnError: false,
+      });
+
+      await assertRejects(
+        () => client.query("query { test }", undefined, { throwOnError: true }),
+        GraphqlExecutionError,
+      );
+      await client.close();
+    },
+  );
+});
+
+Deno.test("GraphqlClient.mutation", async (t) => {
+  await t.step("sends mutation request", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ data: { createUser: { id: 1 } } }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    await client.mutation(
+      "mutation CreateUser($name: String!) { createUser(name: $name) { id } }",
+      { name: "John" },
+    );
+    await client.close();
+
+    const body = await capturedRequest?.json();
+    assertEquals(body.query.includes("mutation"), true);
+    assertEquals(body.variables, { name: "John" });
+  });
+});
+
+Deno.test("GraphqlClient.execute", async (t) => {
+  await t.step("works for queries", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response(JSON.stringify({ data: { test: true } }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    const response = await client.execute("query { test }");
+    await client.close();
+
+    assertEquals(response.data, { test: true });
+  });
+
+  await t.step("works for mutations", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response(JSON.stringify({ data: { updated: true } }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    const response = await client.execute("mutation { updateSomething }");
+    await client.close();
+
+    assertEquals(response.data, { updated: true });
+  });
+});
+
+Deno.test("GraphqlClient headers", async (t) => {
+  await t.step("sends Content-Type header", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ data: null }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    await client.query("query { test }");
+    await client.close();
+
+    assertEquals(
+      capturedRequest?.headers.get("Content-Type"),
+      "application/json",
+    );
+  });
+
+  await t.step("merges headers from config and options", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ data: null }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      headers: { Authorization: "Bearer token" },
+      fetch: mockFetch,
+    });
+
+    await client.query("query { test }", undefined, {
+      headers: { "X-Request-Id": "abc" },
+    });
+    await client.close();
+
+    assertEquals(capturedRequest?.headers.get("Authorization"), "Bearer token");
+    assertEquals(capturedRequest?.headers.get("X-Request-Id"), "abc");
+    assertEquals(
+      capturedRequest?.headers.get("Content-Type"),
+      "application/json",
+    );
+  });
+
+  await t.step("option headers override config headers", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch = createMockFetch((req) => {
+      capturedRequest = req;
+      return new Response(JSON.stringify({ data: null }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      headers: { Authorization: "Bearer old-token" },
+      fetch: mockFetch,
+    });
+
+    await client.query("query { test }", undefined, {
+      headers: { Authorization: "Bearer new-token" },
+    });
+    await client.close();
+
+    assertEquals(
+      capturedRequest?.headers.get("Authorization"),
+      "Bearer new-token",
+    );
+  });
+});
+
+Deno.test("GraphqlClient response", async (t) => {
+  await t.step("includes duration in response", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response(JSON.stringify({ data: { test: true } }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    const response = await client.query("query { test }");
+    await client.close();
+
+    assertEquals(typeof response.duration, "number");
+    assertEquals(response.duration >= 0, true);
+  });
+
+  await t.step("includes status in response", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response(JSON.stringify({ data: null }), { status: 200 });
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    const response = await client.query("query { test }");
+    await client.close();
+
+    assertEquals(response.status, 200);
+  });
+
+  await t.step("includes extensions in response", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response(
+        JSON.stringify({
+          data: { test: true },
+          extensions: { tracing: { duration: 123 } },
+        }),
+      );
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    const response = await client.query("query { test }");
+    await client.close();
+
+    assertEquals(response.extensions, { tracing: { duration: 123 } });
+  });
+
+  await t.step("includes raw response", async () => {
+    const mockFetch = createMockFetch(() => {
+      return new Response(JSON.stringify({ data: null }));
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    const response = await client.query("query { test }");
+    await client.close();
+
+    assertInstanceOf(response.raw, Response);
+  });
+});
+
+Deno.test("GraphqlClient network errors", async (t) => {
+  await t.step("throws GraphqlNetworkError on fetch failure", async () => {
+    const mockFetch = createMockFetch(() => {
+      throw new TypeError("fetch failed");
+    });
+
+    const client = createGraphqlClient({
+      endpoint: "http://localhost:4000/graphql",
+      fetch: mockFetch,
+    });
+
+    const error = await assertRejects(
+      () => client.query("query { test }"),
+      GraphqlNetworkError,
+    );
+    assertInstanceOf(error, GraphqlNetworkError);
+    assertEquals(error.message.includes("Network error"), true);
+    await client.close();
+  });
+
+  await t.step(
+    "throws GraphqlNetworkError on non-200 HTTP response",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response("Internal Server Error", {
+          status: 500,
+          statusText: "Internal Server Error",
+        });
+      });
+
+      const client = createGraphqlClient({
+        endpoint: "http://localhost:4000/graphql",
+        fetch: mockFetch,
+      });
+
+      const error = await assertRejects(
+        () => client.query("query { test }"),
+        GraphqlNetworkError,
+      );
+      assertEquals(error.message, "HTTP 500: Internal Server Error");
+      await client.close();
+    },
+  );
+
+  await t.step(
+    "throws GraphqlNetworkError on invalid JSON response",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response("not json", { status: 200 });
+      });
+
+      const client = createGraphqlClient({
+        endpoint: "http://localhost:4000/graphql",
+        fetch: mockFetch,
+      });
+
+      const error = await assertRejects(
+        () => client.query("query { test }"),
+        GraphqlNetworkError,
+      );
+      assertEquals(error.message.includes("Failed to parse"), true);
+      await client.close();
+    },
+  );
+});
+
+Deno.test("GraphqlClient partial data with errors", async (t) => {
+  await t.step(
+    "returns partial data with errors when throwOnError: false",
+    async () => {
+      const mockFetch = createMockFetch(() => {
+        return new Response(
+          JSON.stringify({
+            data: { user: { id: 1 }, posts: null },
+            errors: [{ message: "Posts service unavailable", path: ["posts"] }],
+          }),
+        );
+      });
+
+      const client = createGraphqlClient({
+        endpoint: "http://localhost:4000/graphql",
+        fetch: mockFetch,
+        throwOnError: false,
+      });
+
+      const response = await client.query("query { user { id } posts { id } }");
+      await client.close();
+
+      assertEquals(response.ok, false);
+      assertEquals(response.data, { user: { id: 1 }, posts: null });
+      assertEquals(response.errors?.length, 1);
+    },
+  );
+});

--- a/packages/probitas-client-graphql/deno.json
+++ b/packages/probitas-client-graphql/deno.json
@@ -1,0 +1,12 @@
+{
+  "name": "@probitas/client-graphql",
+  "version": "0.0.0",
+  "exports": "./mod.ts",
+  "publish": {
+    "exclude": ["**/*_test.ts", "**/*_bench.ts"]
+  },
+  "imports": {
+    "@probitas/client": "jsr:@probitas/client@^0",
+    "@cspotcode/outdent": "jsr:@cspotcode/outdent@^0.8.0"
+  }
+}

--- a/packages/probitas-client-graphql/errors.ts
+++ b/packages/probitas-client-graphql/errors.ts
@@ -1,0 +1,79 @@
+import { ClientError } from "@probitas/client";
+import type { GraphqlErrorItem, GraphqlResponse } from "./types.ts";
+
+/**
+ * Options for GraphqlError constructor.
+ */
+export interface GraphqlErrorOptions extends ErrorOptions {
+  /** Associated GraphQL response */
+  readonly response?: GraphqlResponse;
+}
+
+/**
+ * Base GraphQL error class.
+ */
+export class GraphqlError extends ClientError {
+  override readonly name: string = "GraphqlError";
+  override readonly kind = "graphql" as const;
+
+  /** GraphQL errors from response */
+  readonly errors: readonly GraphqlErrorItem[];
+
+  /** Associated GraphQL response (if available) */
+  readonly response?: GraphqlResponse;
+
+  constructor(
+    message: string,
+    errors: readonly GraphqlErrorItem[],
+    options?: GraphqlErrorOptions,
+  ) {
+    super(message, "graphql", options);
+    this.errors = errors;
+    this.response = options?.response;
+  }
+}
+
+/**
+ * Error thrown for network/HTTP errors before GraphQL processing.
+ */
+export class GraphqlNetworkError extends GraphqlError {
+  override readonly name = "GraphqlNetworkError";
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, [], options);
+  }
+}
+
+/**
+ * Error thrown for GraphQL validation errors.
+ */
+export class GraphqlValidationError extends GraphqlError {
+  override readonly name = "GraphqlValidationError";
+
+  constructor(
+    errors: readonly GraphqlErrorItem[],
+    options?: GraphqlErrorOptions,
+  ) {
+    const message = `GraphQL validation failed: ${
+      errors.map((e) => e.message).join("; ")
+    }`;
+    super(message, errors, options);
+  }
+}
+
+/**
+ * Error thrown for GraphQL execution errors.
+ */
+export class GraphqlExecutionError extends GraphqlError {
+  override readonly name = "GraphqlExecutionError";
+
+  constructor(
+    errors: readonly GraphqlErrorItem[],
+    options?: GraphqlErrorOptions,
+  ) {
+    const message = `GraphQL execution failed: ${
+      errors.map((e) => e.message).join("; ")
+    }`;
+    super(message, errors, options);
+  }
+}

--- a/packages/probitas-client-graphql/errors_test.ts
+++ b/packages/probitas-client-graphql/errors_test.ts
@@ -1,0 +1,112 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { ClientError } from "@probitas/client";
+import {
+  GraphqlError,
+  GraphqlExecutionError,
+  GraphqlNetworkError,
+  GraphqlValidationError,
+} from "./errors.ts";
+
+Deno.test("GraphqlError", async (t) => {
+  await t.step("extends ClientError", () => {
+    const error = new GraphqlError("request failed", []);
+    assertInstanceOf(error, ClientError);
+    assertInstanceOf(error, GraphqlError);
+  });
+
+  await t.step("has correct properties", () => {
+    const errors = [{ message: "Field not found" }];
+    const error = new GraphqlError("GraphQL errors occurred", errors);
+    assertEquals(error.name, "GraphqlError");
+    assertEquals(error.kind, "graphql");
+    assertEquals(error.message, "GraphQL errors occurred");
+    assertEquals(error.errors, errors);
+    assertEquals(error.response, undefined);
+  });
+
+  await t.step("supports response property", () => {
+    const mockResponse = { ok: false } as never;
+    const error = new GraphqlError("request failed", [], {
+      response: mockResponse,
+    });
+    assertEquals(error.response, mockResponse);
+  });
+
+  await t.step("supports cause option", () => {
+    const cause = new Error("network error");
+    const error = new GraphqlError("request failed", [], { cause });
+    assertEquals(error.cause, cause);
+  });
+});
+
+Deno.test("GraphqlNetworkError", async (t) => {
+  await t.step("extends GraphqlError", () => {
+    const error = new GraphqlNetworkError("connection refused");
+    assertInstanceOf(error, GraphqlError);
+    assertInstanceOf(error, GraphqlNetworkError);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new GraphqlNetworkError("connection refused");
+    assertEquals(error.name, "GraphqlNetworkError");
+    assertEquals(error.kind, "graphql");
+    assertEquals(error.message, "connection refused");
+    assertEquals(error.errors, []);
+  });
+
+  await t.step("supports cause option", () => {
+    const cause = new TypeError("fetch failed");
+    const error = new GraphqlNetworkError("network error", { cause });
+    assertEquals(error.cause, cause);
+  });
+});
+
+Deno.test("GraphqlValidationError", async (t) => {
+  await t.step("extends GraphqlError", () => {
+    const errors = [{ message: "Unknown field" }];
+    const error = new GraphqlValidationError(errors);
+    assertInstanceOf(error, GraphqlError);
+    assertInstanceOf(error, GraphqlValidationError);
+  });
+
+  await t.step("has correct properties", () => {
+    const errors = [
+      { message: "Unknown field 'foo'" },
+      { message: "Cannot query field 'bar'" },
+    ];
+    const error = new GraphqlValidationError(errors);
+    assertEquals(error.name, "GraphqlValidationError");
+    assertEquals(error.kind, "graphql");
+    assertEquals(error.errors, errors);
+    assertEquals(
+      error.message,
+      "GraphQL validation failed: Unknown field 'foo'; Cannot query field 'bar'",
+    );
+  });
+});
+
+Deno.test("GraphqlExecutionError", async (t) => {
+  await t.step("extends GraphqlError", () => {
+    const errors = [{ message: "Resolver failed" }];
+    const error = new GraphqlExecutionError(errors);
+    assertInstanceOf(error, GraphqlError);
+    assertInstanceOf(error, GraphqlExecutionError);
+  });
+
+  await t.step("has correct properties", () => {
+    const errors = [{ message: "User not found" }];
+    const error = new GraphqlExecutionError(errors);
+    assertEquals(error.name, "GraphqlExecutionError");
+    assertEquals(error.kind, "graphql");
+    assertEquals(error.errors, errors);
+    assertEquals(error.message, "GraphQL execution failed: User not found");
+  });
+
+  await t.step("supports response property", () => {
+    const mockResponse = { ok: false, data: null } as never;
+    const error = new GraphqlExecutionError([{ message: "error" }], {
+      response: mockResponse,
+    });
+    assertEquals(error.response, mockResponse);
+  });
+});

--- a/packages/probitas-client-graphql/expect.ts
+++ b/packages/probitas-client-graphql/expect.ts
@@ -1,0 +1,211 @@
+import type { GraphqlResponse } from "./types.ts";
+
+/**
+ * Fluent API for GraphQL response validation.
+ */
+export interface GraphqlResponseExpectation {
+  /** Assert that response has no errors */
+  ok(): this;
+
+  /** Assert that response has errors */
+  hasErrors(): this;
+
+  /** Assert exact number of errors */
+  errorCount(n: number): this;
+
+  /** Assert that at least one error contains the message */
+  errorContains(message: string): this;
+
+  /** Assert errors using custom matcher */
+  errorMatch(matcher: (errors: readonly { message: string }[]) => void): this;
+
+  /** Assert that data is not null */
+  hasData(): this;
+
+  /** Assert that data is null */
+  noData(): this;
+
+  /** Assert that data contains expected subset (deep partial match) */
+  // deno-lint-ignore no-explicit-any
+  dataContains<T = any>(subset: Partial<T>): this;
+
+  /** Assert data using custom matcher */
+  // deno-lint-ignore no-explicit-any
+  dataMatch<T = any>(matcher: (data: T) => void): this;
+
+  /** Assert that an extension key exists */
+  extensionExists(key: string): this;
+
+  /** Assert extension using custom matcher */
+  extensionMatch(key: string, matcher: (value: unknown) => void): this;
+
+  /** Assert HTTP status code */
+  status(code: number): this;
+
+  /** Assert that response duration is less than threshold (ms) */
+  durationLessThan(ms: number): this;
+}
+
+/**
+ * Deep partial match check.
+ */
+function containsSubset(obj: unknown, subset: unknown): boolean {
+  if (subset === null || typeof subset !== "object") {
+    return obj === subset;
+  }
+  if (obj === null || typeof obj !== "object") {
+    return false;
+  }
+  for (const key of Object.keys(subset)) {
+    if (
+      !containsSubset(
+        (obj as Record<string, unknown>)[key],
+        (subset as Record<string, unknown>)[key],
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * GraphqlResponseExpectation implementation.
+ */
+class GraphqlResponseExpectationImpl implements GraphqlResponseExpectation {
+  readonly #response: GraphqlResponse;
+
+  constructor(response: GraphqlResponse) {
+    this.#response = response;
+  }
+
+  ok(): this {
+    if (!this.#response.ok) {
+      const errorMessages = this.#response.errors
+        ?.map((e) => e.message)
+        .join("; ");
+      throw new Error(`Expected ok response, got errors: ${errorMessages}`);
+    }
+    return this;
+  }
+
+  hasErrors(): this {
+    if (this.#response.ok) {
+      throw new Error("Expected response with errors, but got ok response");
+    }
+    return this;
+  }
+
+  errorCount(n: number): this {
+    const actual = this.#response.errors?.length ?? 0;
+    if (actual !== n) {
+      throw new Error(`Expected ${n} errors, got ${actual}`);
+    }
+    return this;
+  }
+
+  errorContains(message: string): this {
+    if (!this.#response.errors || this.#response.errors.length === 0) {
+      throw new Error(
+        `Expected an error containing "${message}", but no errors present`,
+      );
+    }
+    const found = this.#response.errors.some((e) =>
+      e.message.includes(message)
+    );
+    if (!found) {
+      throw new Error(
+        `Expected an error containing "${message}", but none found`,
+      );
+    }
+    return this;
+  }
+
+  errorMatch(matcher: (errors: readonly { message: string }[]) => void): this {
+    if (!this.#response.errors) {
+      throw new Error("Cannot match errors: no errors present");
+    }
+    matcher(this.#response.errors);
+    return this;
+  }
+
+  hasData(): this {
+    if (this.#response.data === null) {
+      throw new Error("Expected data, but data is null");
+    }
+    return this;
+  }
+
+  noData(): this {
+    if (this.#response.data !== null) {
+      throw new Error("Expected no data, but data exists");
+    }
+    return this;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  dataContains<T = any>(subset: Partial<T>): this {
+    if (this.#response.data === null) {
+      throw new Error("Expected data to contain subset, but data is null");
+    }
+    if (!containsSubset(this.#response.data, subset)) {
+      throw new Error(
+        `Expected data to contain ${JSON.stringify(subset)}, got ${
+          JSON.stringify(this.#response.data)
+        }`,
+      );
+    }
+    return this;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  dataMatch<T = any>(matcher: (data: T) => void): this {
+    if (this.#response.data === null) {
+      throw new Error("Cannot match data: data is null");
+    }
+    matcher(this.#response.data as T);
+    return this;
+  }
+
+  extensionExists(key: string): this {
+    if (!this.#response.extensions || !(key in this.#response.extensions)) {
+      throw new Error(`Expected extension "${key}" to exist`);
+    }
+    return this;
+  }
+
+  extensionMatch(key: string, matcher: (value: unknown) => void): this {
+    if (!this.#response.extensions || !(key in this.#response.extensions)) {
+      throw new Error(`Extension "${key}" not found`);
+    }
+    matcher(this.#response.extensions[key]);
+    return this;
+  }
+
+  status(code: number): this {
+    if (this.#response.status !== code) {
+      throw new Error(
+        `Expected status ${code}, got ${this.#response.status}`,
+      );
+    }
+    return this;
+  }
+
+  durationLessThan(ms: number): this {
+    if (this.#response.duration >= ms) {
+      throw new Error(
+        `Expected duration < ${ms}ms, got ${this.#response.duration}ms`,
+      );
+    }
+    return this;
+  }
+}
+
+/**
+ * Create a fluent expectation chain for GraphQL response validation.
+ */
+export function expectGraphqlResponse(
+  response: GraphqlResponse,
+): GraphqlResponseExpectation {
+  return new GraphqlResponseExpectationImpl(response);
+}

--- a/packages/probitas-client-graphql/expect_test.ts
+++ b/packages/probitas-client-graphql/expect_test.ts
@@ -1,0 +1,357 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { expectGraphqlResponse } from "./expect.ts";
+import { createGraphqlResponse } from "./response.ts";
+import type { GraphqlResponse } from "./types.ts";
+
+function createMockResponse<T>(
+  overrides: Partial<{
+    data: T | null;
+    errors: { message: string }[] | null;
+    extensions: Record<string, unknown>;
+    duration: number;
+    status: number;
+  }> = {},
+): GraphqlResponse<T> {
+  return createGraphqlResponse({
+    data: overrides.data ?? null,
+    errors: overrides.errors ?? null,
+    extensions: overrides.extensions,
+    duration: overrides.duration ?? 100,
+    status: overrides.status ?? 200,
+    raw: new Response(),
+  });
+}
+
+Deno.test("expectGraphqlResponse.ok()", async (t) => {
+  await t.step("passes when no errors", () => {
+    const response = createMockResponse({ data: { test: true }, errors: null });
+    expectGraphqlResponse(response).ok();
+  });
+
+  await t.step("passes when errors is empty array", () => {
+    const response = createMockResponse({ data: { test: true }, errors: [] });
+    expectGraphqlResponse(response).ok();
+  });
+
+  await t.step("throws when errors present", () => {
+    const response = createMockResponse({
+      errors: [{ message: "Error" }],
+    });
+    assertThrows(
+      () => expectGraphqlResponse(response).ok(),
+      Error,
+      "Expected ok response",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.hasErrors()", async (t) => {
+  await t.step("passes when errors present", () => {
+    const response = createMockResponse({
+      errors: [{ message: "Error" }],
+    });
+    expectGraphqlResponse(response).hasErrors();
+  });
+
+  await t.step("throws when no errors", () => {
+    const response = createMockResponse({ data: { test: true }, errors: null });
+    assertThrows(
+      () => expectGraphqlResponse(response).hasErrors(),
+      Error,
+      "Expected response with errors",
+    );
+  });
+
+  await t.step("throws when errors is empty array", () => {
+    const response = createMockResponse({ data: { test: true }, errors: [] });
+    assertThrows(() => expectGraphqlResponse(response).hasErrors());
+  });
+});
+
+Deno.test("expectGraphqlResponse.errorCount()", async (t) => {
+  await t.step("passes when count matches", () => {
+    const response = createMockResponse({
+      errors: [{ message: "Error 1" }, { message: "Error 2" }],
+    });
+    expectGraphqlResponse(response).errorCount(2);
+  });
+
+  await t.step("passes when count is 0 and no errors", () => {
+    const response = createMockResponse({ data: { test: true }, errors: null });
+    expectGraphqlResponse(response).errorCount(0);
+  });
+
+  await t.step("throws when count does not match", () => {
+    const response = createMockResponse({
+      errors: [{ message: "Error" }],
+    });
+    assertThrows(
+      () => expectGraphqlResponse(response).errorCount(2),
+      Error,
+      "Expected 2 errors, got 1",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.errorContains()", async (t) => {
+  await t.step("passes when error contains message", () => {
+    const response = createMockResponse({
+      errors: [{ message: "User not found" }],
+    });
+    expectGraphqlResponse(response).errorContains("not found");
+  });
+
+  await t.step("passes when any error contains message", () => {
+    const response = createMockResponse({
+      errors: [
+        { message: "First error" },
+        { message: "User not found" },
+      ],
+    });
+    expectGraphqlResponse(response).errorContains("not found");
+  });
+
+  await t.step("throws when no error contains message", () => {
+    const response = createMockResponse({
+      errors: [{ message: "Something else" }],
+    });
+    assertThrows(
+      () => expectGraphqlResponse(response).errorContains("not found"),
+      Error,
+      'Expected an error containing "not found"',
+    );
+  });
+
+  await t.step("throws when no errors", () => {
+    const response = createMockResponse({ data: { test: true }, errors: null });
+    assertThrows(
+      () => expectGraphqlResponse(response).errorContains("error"),
+      Error,
+      "no errors present",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.errorMatch()", async (t) => {
+  await t.step("passes matcher function to errors", () => {
+    const response = createMockResponse({
+      errors: [{ message: "Error 1" }, { message: "Error 2" }],
+    });
+    expectGraphqlResponse(response).errorMatch((errors) => {
+      assertEquals(errors.length, 2);
+      assertEquals(errors[0].message, "Error 1");
+    });
+  });
+
+  await t.step("throws when no errors", () => {
+    const response = createMockResponse({ data: { test: true }, errors: null });
+    assertThrows(
+      () => expectGraphqlResponse(response).errorMatch(() => {}),
+      Error,
+      "Cannot match errors",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.dataContains()", async (t) => {
+  await t.step("passes when data contains subset", () => {
+    const response = createMockResponse({
+      data: { user: { id: 1, name: "John", email: "john@example.com" } },
+    });
+    expectGraphqlResponse(response).dataContains({ user: { id: 1 } });
+  });
+
+  await t.step("passes with nested objects", () => {
+    const response = createMockResponse({
+      data: { user: { profile: { age: 30, city: "NYC" } } },
+    });
+    expectGraphqlResponse(response).dataContains({
+      user: { profile: { age: 30 } },
+    });
+  });
+
+  await t.step("throws when data does not contain subset", () => {
+    const response = createMockResponse({
+      data: { user: { id: 1 } },
+    });
+    assertThrows(
+      () => expectGraphqlResponse(response).dataContains({ user: { id: 2 } }),
+      Error,
+      "Expected data to contain",
+    );
+  });
+
+  await t.step("throws when data is null", () => {
+    const response = createMockResponse({ data: null, errors: null });
+    assertThrows(
+      () => expectGraphqlResponse(response).dataContains({ test: true }),
+      Error,
+      "data is null",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.dataMatch()", async (t) => {
+  await t.step("passes matcher function to data", () => {
+    const response = createMockResponse({
+      data: { count: 5 },
+    });
+    expectGraphqlResponse(response).dataMatch((data: { count: number }) => {
+      assertEquals(data.count, 5);
+    });
+  });
+
+  await t.step("throws when data is null", () => {
+    const response = createMockResponse({ data: null, errors: null });
+    assertThrows(
+      () => expectGraphqlResponse(response).dataMatch(() => {}),
+      Error,
+      "data is null",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.extensionExists()", async (t) => {
+  await t.step("passes when extension exists", () => {
+    const response = createMockResponse({
+      data: { test: true },
+      extensions: { tracing: { duration: 100 } },
+    });
+    expectGraphqlResponse(response).extensionExists("tracing");
+  });
+
+  await t.step("throws when extension does not exist", () => {
+    const response = createMockResponse({
+      data: { test: true },
+      extensions: { other: {} },
+    });
+    assertThrows(
+      () => expectGraphqlResponse(response).extensionExists("tracing"),
+      Error,
+      'Expected extension "tracing" to exist',
+    );
+  });
+
+  await t.step("throws when no extensions", () => {
+    const response = createMockResponse({ data: { test: true } });
+    assertThrows(
+      () => expectGraphqlResponse(response).extensionExists("tracing"),
+      Error,
+      'Expected extension "tracing" to exist',
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.extensionMatch()", async (t) => {
+  await t.step("passes matcher function to extension value", () => {
+    const response = createMockResponse({
+      data: { test: true },
+      extensions: { tracing: { duration: 100 } },
+    });
+    expectGraphqlResponse(response).extensionMatch(
+      "tracing",
+      (value: unknown) => {
+        assertEquals(value, { duration: 100 });
+      },
+    );
+  });
+
+  await t.step("throws when extension not found", () => {
+    const response = createMockResponse({
+      data: { test: true },
+      extensions: { other: {} },
+    });
+    assertThrows(
+      () => expectGraphqlResponse(response).extensionMatch("tracing", () => {}),
+      Error,
+      'Extension "tracing" not found',
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.durationLessThan()", async (t) => {
+  await t.step("passes when duration is less", () => {
+    const response = createMockResponse({ data: null, duration: 50 });
+    expectGraphqlResponse(response).durationLessThan(100);
+  });
+
+  await t.step("throws when duration is equal", () => {
+    const response = createMockResponse({ data: null, duration: 100 });
+    assertThrows(
+      () => expectGraphqlResponse(response).durationLessThan(100),
+      Error,
+      "Expected duration < 100ms, got 100ms",
+    );
+  });
+
+  await t.step("throws when duration is greater", () => {
+    const response = createMockResponse({ data: null, duration: 150 });
+    assertThrows(
+      () => expectGraphqlResponse(response).durationLessThan(100),
+      Error,
+      "Expected duration < 100ms, got 150ms",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse fluent chaining", () => {
+  const response = createMockResponse({
+    data: { user: { id: 1 } },
+    extensions: { tracing: {} },
+    duration: 50,
+  });
+
+  expectGraphqlResponse(response)
+    .ok()
+    .dataContains({ user: { id: 1 } })
+    .extensionExists("tracing")
+    .durationLessThan(100);
+});
+
+Deno.test("expectGraphqlResponse.status()", async (t) => {
+  await t.step("passes when status matches", () => {
+    const response = createMockResponse({ data: null, status: 200 });
+    expectGraphqlResponse(response).status(200);
+  });
+
+  await t.step("throws when status does not match", () => {
+    const response = createMockResponse({ data: null, status: 500 });
+    assertThrows(
+      () => expectGraphqlResponse(response).status(200),
+      Error,
+      "Expected status 200, got 500",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.hasData()", async (t) => {
+  await t.step("passes when data is not null", () => {
+    const response = createMockResponse({ data: { test: true } });
+    expectGraphqlResponse(response).hasData();
+  });
+
+  await t.step("throws when data is null", () => {
+    const response = createMockResponse({ data: null });
+    assertThrows(
+      () => expectGraphqlResponse(response).hasData(),
+      Error,
+      "Expected data, but data is null",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.noData()", async (t) => {
+  await t.step("passes when data is null", () => {
+    const response = createMockResponse({ data: null });
+    expectGraphqlResponse(response).noData();
+  });
+
+  await t.step("throws when data is not null", () => {
+    const response = createMockResponse({ data: { test: true } });
+    assertThrows(
+      () => expectGraphqlResponse(response).noData(),
+      Error,
+      "Expected no data, but data exists",
+    );
+  });
+});

--- a/packages/probitas-client-graphql/integration_test.ts
+++ b/packages/probitas-client-graphql/integration_test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration tests for @probitas/client-graphql.
+ *
+ * Run with:
+ *   docker compose up -d
+ *   deno test -A packages/probitas-client-graphql/integration_test.ts
+ *   docker compose down
+ */
+
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import {
+  createGraphqlClient,
+  expectGraphqlResponse,
+  GraphqlExecutionError,
+  outdent,
+} from "./mod.ts";
+
+const GRAPHQL_URL = Deno.env.get("GRAPHQL_URL") ??
+  "http://localhost:14000/graphql";
+
+async function isGraphqlServerAvailable(): Promise<boolean> {
+  try {
+    const res = await fetch(GRAPHQL_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "{ __typename }" }),
+      signal: AbortSignal.timeout(1000),
+    });
+    await res.body?.cancel();
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test({
+  name: "Integration: GraphQL",
+  ignore: !(await isGraphqlServerAvailable()),
+  async fn(t) {
+    const client = createGraphqlClient({ endpoint: GRAPHQL_URL });
+
+    await t.step("introspection query - __typename", async () => {
+      const res = await client.query<{ __typename: string }>(
+        "{ __typename }",
+      );
+
+      expectGraphqlResponse(res)
+        .ok()
+        .status(200)
+        .hasData();
+
+      assertEquals(res.data?.__typename, "Query");
+    });
+
+    await t.step("introspection query - __schema", async () => {
+      const res = await client.query<{
+        __schema: { queryType: { name: string } };
+      }>("{ __schema { queryType { name } } }");
+
+      expectGraphqlResponse(res).ok().hasData();
+
+      assertEquals(res.data?.__schema.queryType.name, "Query");
+    });
+
+    await t.step("query with variables", async () => {
+      // Using introspection to test variables since it's available on all GraphQL servers
+      const res = await client.query<{ __type: { name: string } | null }>(
+        outdent`
+          query GetType($name: String!) {
+            __type(name: $name) {
+              name
+            }
+          }
+        `,
+        { name: "Query" },
+      );
+
+      expectGraphqlResponse(res).ok();
+      assertEquals(res.data?.__type?.name, "Query");
+    });
+
+    await t.step("query with operationName", async () => {
+      const res = await client.query(
+        outdent`
+          query FirstQuery { __typename }
+          query SecondQuery { __schema { queryType { name } } }
+        `,
+        undefined,
+        { operationName: "FirstQuery" },
+      );
+
+      expectGraphqlResponse(res).ok();
+    });
+
+    await t.step("includes duration in response", async () => {
+      const res = await client.query("{ __typename }");
+
+      assertEquals(typeof res.duration, "number");
+      assertEquals(res.duration >= 0, true);
+    });
+
+    await t.step("includes status in response", async () => {
+      const res = await client.query("{ __typename }");
+
+      assertEquals(res.status, 200);
+    });
+
+    await t.step("includes raw response", async () => {
+      const res = await client.query("{ __typename }");
+
+      assertInstanceOf(res.raw, Response);
+    });
+
+    await t.step("using await using (AsyncDisposable)", async () => {
+      await using c = createGraphqlClient({ endpoint: GRAPHQL_URL });
+
+      const res = await c.query("{ __typename }");
+      expectGraphqlResponse(res).ok();
+    });
+
+    await t.step("default headers from config", async () => {
+      // Cannot directly verify headers were sent, but can verify the request succeeds
+      const clientWithHeaders = createGraphqlClient({
+        endpoint: GRAPHQL_URL,
+        headers: {
+          "Authorization": "Bearer test-token",
+          "X-Custom-Header": "custom-value",
+        },
+      });
+
+      const res = await clientWithHeaders.query("{ __typename }");
+      expectGraphqlResponse(res).ok();
+
+      await clientWithHeaders.close();
+    });
+
+    await t.step("request headers override config headers", async () => {
+      const clientWithHeaders = createGraphqlClient({
+        endpoint: GRAPHQL_URL,
+        headers: { "X-Header": "from-config" },
+      });
+
+      const res = await clientWithHeaders.query(
+        "{ __typename }",
+        undefined,
+        { headers: { "X-Header": "from-request" } },
+      );
+
+      expectGraphqlResponse(res).ok();
+
+      await clientWithHeaders.close();
+    });
+
+    await t.step(
+      "throws GraphqlExecutionError on validation error",
+      async () => {
+        try {
+          await client.query("{ nonExistentField }");
+          throw new Error("Expected GraphqlExecutionError");
+        } catch (error) {
+          assertInstanceOf(error, GraphqlExecutionError);
+          assertEquals(error.errors.length > 0, true);
+        }
+      },
+    );
+
+    await t.step(
+      "returns errors without throwing when throwOnError: false",
+      async () => {
+        const clientNoThrow = createGraphqlClient({
+          endpoint: GRAPHQL_URL,
+          throwOnError: false,
+        });
+
+        const res = await clientNoThrow.query("{ nonExistentField }");
+
+        expectGraphqlResponse(res)
+          .hasErrors()
+          .errorContains("nonExistentField");
+
+        await clientNoThrow.close();
+      },
+    );
+
+    await t.step("execute() works for queries", async () => {
+      const res = await client.execute("query { __typename }");
+
+      expectGraphqlResponse(res).ok();
+    });
+
+    await t.step("mutation method works", async () => {
+      // Using introspection as a "mutation" since we can't guarantee
+      // the test server has actual mutations. The method should still
+      // send the request correctly.
+      const res = await client.mutation("query { __typename }");
+
+      expectGraphqlResponse(res).ok();
+    });
+
+    await t.step("fluent expectation chaining", async () => {
+      const res = await client.query<{ __typename: string }>("{ __typename }");
+
+      expectGraphqlResponse(res)
+        .ok()
+        .status(200)
+        .hasData()
+        .dataContains({ __typename: "Query" })
+        .durationLessThan(5000);
+    });
+
+    await client.close();
+  },
+});

--- a/packages/probitas-client-graphql/mod.ts
+++ b/packages/probitas-client-graphql/mod.ts
@@ -1,0 +1,36 @@
+/**
+ * @probitas/client-graphql - GraphQL client for Probitas scenario testing framework.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   createGraphqlClient,
+ *   expectGraphqlResponse,
+ *   outdent,
+ * } from "@probitas/client-graphql";
+ *
+ * const client = createGraphqlClient({ endpoint: "http://localhost:4000/graphql" });
+ *
+ * const res = await client.query(outdent`
+ *   query GetUser($id: ID!) {
+ *     user(id: $id) { id name email }
+ *   }
+ * `, { id: "123" });
+ *
+ * expectGraphqlResponse(res)
+ *   .ok()
+ *   .dataContains({ user: { id: "123" } })
+ *   .durationLessThan(1000);
+ *
+ * await client.close();
+ * ```
+ *
+ * @module
+ */
+
+export type * from "./types.ts";
+export * from "./errors.ts";
+export { createGraphqlClient } from "./client.ts";
+export * from "./response.ts";
+export * from "./expect.ts";
+export { outdent } from "@cspotcode/outdent";

--- a/packages/probitas-client-graphql/response.ts
+++ b/packages/probitas-client-graphql/response.ts
@@ -1,0 +1,45 @@
+import type { GraphqlErrorItem, GraphqlResponse } from "./types.ts";
+
+/**
+ * Options for creating a GraphqlResponse.
+ */
+export interface GraphqlResponseOptions<T> {
+  readonly data: T | null;
+  readonly errors: readonly GraphqlErrorItem[] | null;
+  readonly extensions?: Record<string, unknown>;
+  readonly duration: number;
+  readonly status: number;
+  readonly raw: globalThis.Response;
+}
+
+/**
+ * Implementation of GraphqlResponse.
+ */
+class GraphqlResponseImpl<T> implements GraphqlResponse<T> {
+  readonly ok: boolean;
+  readonly data: T | null;
+  readonly errors: readonly GraphqlErrorItem[] | null;
+  readonly extensions?: Record<string, unknown>;
+  readonly duration: number;
+  readonly status: number;
+  readonly raw: globalThis.Response;
+
+  constructor(options: GraphqlResponseOptions<T>) {
+    this.data = options.data;
+    this.errors = options.errors;
+    this.ok = options.errors === null || options.errors.length === 0;
+    this.extensions = options.extensions;
+    this.duration = options.duration;
+    this.status = options.status;
+    this.raw = options.raw;
+  }
+}
+
+/**
+ * Create a GraphqlResponse from parsed response data.
+ */
+export function createGraphqlResponse<T>(
+  options: GraphqlResponseOptions<T>,
+): GraphqlResponse<T> {
+  return new GraphqlResponseImpl(options);
+}

--- a/packages/probitas-client-graphql/response_test.ts
+++ b/packages/probitas-client-graphql/response_test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from "@std/assert";
+import { createGraphqlResponse } from "./response.ts";
+
+Deno.test("createGraphqlResponse", async (t) => {
+  await t.step("creates response with data and no errors", () => {
+    const response = createGraphqlResponse({
+      data: { user: { id: 1, name: "John" } },
+      errors: null,
+      extensions: undefined,
+      duration: 100,
+      status: 200,
+      raw: new Response(),
+    });
+
+    assertEquals(response.ok, true);
+    assertEquals(response.data, { user: { id: 1, name: "John" } });
+    assertEquals(response.errors, null);
+    assertEquals(response.duration, 100);
+    assertEquals(response.status, 200);
+  });
+
+  await t.step("creates response with errors", () => {
+    const errors = [{ message: "Not found" }];
+    const response = createGraphqlResponse({
+      data: null,
+      errors,
+      extensions: undefined,
+      duration: 50,
+      status: 200,
+      raw: new Response(),
+    });
+
+    assertEquals(response.ok, false);
+    assertEquals(response.data, null);
+    assertEquals(response.errors, errors);
+  });
+
+  await t.step("ok is false when errors present even with partial data", () => {
+    const response = createGraphqlResponse({
+      data: { user: null },
+      errors: [{ message: "Field error" }],
+      extensions: undefined,
+      duration: 50,
+      status: 200,
+      raw: new Response(),
+    });
+
+    assertEquals(response.ok, false);
+    assertEquals(response.data, { user: null });
+  });
+
+  await t.step("ok is true when errors is empty array", () => {
+    const response = createGraphqlResponse({
+      data: { test: true },
+      errors: [],
+      extensions: undefined,
+      duration: 50,
+      status: 200,
+      raw: new Response(),
+    });
+
+    assertEquals(response.ok, true);
+  });
+
+  await t.step("includes extensions", () => {
+    const response = createGraphqlResponse({
+      data: { test: true },
+      errors: null,
+      extensions: { tracing: { duration: 123 } },
+      duration: 50,
+      status: 200,
+      raw: new Response(),
+    });
+
+    assertEquals(response.extensions, { tracing: { duration: 123 } });
+  });
+
+  await t.step("includes raw response", () => {
+    const rawResponse = new Response();
+    const response = createGraphqlResponse({
+      data: null,
+      errors: null,
+      extensions: undefined,
+      duration: 10,
+      status: 200,
+      raw: rawResponse,
+    });
+
+    assertEquals(response.raw, rawResponse);
+  });
+});

--- a/packages/probitas-client-graphql/types.ts
+++ b/packages/probitas-client-graphql/types.ts
@@ -1,0 +1,119 @@
+import type { CommonOptions } from "@probitas/client";
+
+/**
+ * GraphQL error item as per GraphQL specification.
+ * @see https://spec.graphql.org/October2021/#sec-Errors.Error-Result-Format
+ */
+export interface GraphqlErrorItem {
+  /** Error message */
+  readonly message: string;
+
+  /** Location(s) in the GraphQL document where the error occurred */
+  readonly locations?: readonly { line: number; column: number }[];
+
+  /** Path to the field that caused the error */
+  readonly path?: readonly (string | number)[];
+
+  /** Additional error metadata */
+  readonly extensions?: Record<string, unknown>;
+}
+
+/**
+ * GraphQL response interface with pre-loaded body.
+ */
+// deno-lint-ignore no-explicit-any
+export interface GraphqlResponse<T = any> {
+  /** Whether the request was successful (no errors) */
+  readonly ok: boolean;
+
+  /** Response data (null if errors occurred with no partial data) */
+  readonly data: T | null;
+
+  /** GraphQL errors array (null if no errors) */
+  readonly errors: readonly GraphqlErrorItem[] | null;
+
+  /** Response extensions */
+  readonly extensions?: Record<string, unknown>;
+
+  /** Response time in milliseconds */
+  readonly duration: number;
+
+  /** HTTP status code */
+  readonly status: number;
+
+  /** Raw Web standard Response (for streaming or special cases) */
+  readonly raw: globalThis.Response;
+}
+
+/**
+ * Options for individual GraphQL requests.
+ */
+export interface GraphqlOptions extends CommonOptions {
+  /** Additional request headers */
+  readonly headers?: Record<string, string>;
+
+  /** Operation name (for documents with multiple operations) */
+  readonly operationName?: string;
+
+  /**
+   * Whether to throw GraphqlError when response contains errors.
+   * @default true (inherited from client config if not specified)
+   */
+  readonly throwOnError?: boolean;
+}
+
+/**
+ * GraphQL client configuration.
+ */
+export interface GraphqlClientConfig extends CommonOptions {
+  /** GraphQL endpoint URL */
+  readonly endpoint: string;
+
+  /** Default headers for all requests */
+  readonly headers?: Record<string, string>;
+
+  /** Custom fetch implementation (for testing/mocking) */
+  readonly fetch?: typeof fetch;
+
+  /**
+   * Whether to throw GraphqlError when response contains errors.
+   * Can be overridden per-request via GraphqlOptions.
+   * @default true
+   */
+  readonly throwOnError?: boolean;
+}
+
+/**
+ * GraphQL client interface.
+ */
+export interface GraphqlClient extends AsyncDisposable {
+  /** Client configuration */
+  readonly config: GraphqlClientConfig;
+
+  /** Execute a GraphQL query */
+  // deno-lint-ignore no-explicit-any
+  query<TData = any, TVariables = Record<string, any>>(
+    query: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): Promise<GraphqlResponse<TData>>;
+
+  /** Execute a GraphQL mutation */
+  // deno-lint-ignore no-explicit-any
+  mutation<TData = any, TVariables = Record<string, any>>(
+    mutation: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): Promise<GraphqlResponse<TData>>;
+
+  /** Execute a GraphQL document (query or mutation) */
+  // deno-lint-ignore no-explicit-any
+  execute<TData = any, TVariables = Record<string, any>>(
+    document: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): Promise<GraphqlResponse<TData>>;
+
+  /** Close the client and release resources */
+  close(): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- Add GraphQL client package for Probitas scenario testing framework
- Implement `GraphqlClient` with `query`/`mutation`/`execute` methods
- Add `GraphqlResponse` wrapper with `ok`, `data`, `errors`, `extensions`, `duration` properties
- Create error hierarchy: `GraphqlError`, `GraphqlNetworkError`, `GraphqlValidationError`, `GraphqlExecutionError`
- Implement fluent expectation API (`expectGraphqlResponse`) for test assertions
- Re-export `outdent` from `@cspotcode/outdent` for multiline query formatting
- Add integration tests using Docker GraphQL server (`npalm/graphql-java-demo`)

## Test plan
- [x] Unit tests pass (`deno test -A packages/probitas-client-graphql/`)
- [x] Integration tests pass with Docker (`docker compose up -d && deno test -A`)
- [x] Type check passes (`deno task check`)
- [x] Lint passes (`deno lint`)