### PR TITLE
docs: add git stash prohibition rule for worktree environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,3 +194,22 @@ deno task test
 - Run all commands (git, deno, etc.) from within the worktree
 - If you need to check the root repository state, use absolute paths without
   changing directory
+
+### 6. Git Stash is Forbidden in Worktrees
+
+**NEVER use `git stash` in worktree environments.**
+
+Git stash is shared across all worktrees. This causes accidental cross-worktree
+contamination.
+
+**Use backup branch instead:**
+
+```bash
+git checkout -b "backup/$(git branch --show-current)/$(date +%Y%m%d-%H%M%S)"
+git commit -am "WIP: before risky refactoring"
+git checkout -
+git cherry-pick --no-commit HEAD@{1}
+```
+
+This creates a persistent backup branch while keeping changes in your working
+tree.


### PR DESCRIPTION
## Summary

- Add STRICT RULE #6: Git stash is forbidden in worktree environments
- Git stash is shared across all worktrees, causing accidental cross-worktree contamination
- Provide backup branch workflow as safe alternative

## Backup branch workflow

```bash
git checkout -b "backup/$(git branch --show-current)/$(date +%Y%m%d-%H%M%S)"
git commit -am "WIP: before risky refactoring"
git checkout -
git cherry-pick --no-commit HEAD@{1}
```

## Test plan

- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] `deno task check` passes
- [x] `deno task test` passes