### PR TITLE
feat: Implement @probitas/client-sql-mysql package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,20 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mysql:
+        image: mysql:8.0
+        ports:
+          - 13306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: rootpassword
+          MYSQL_DATABASE: testdb
+          MYSQL_USER: testuser
+          MYSQL_PASSWORD: testpassword
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost -u root -prootpassword"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,3 +30,28 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
+  # MySQL server for integration testing
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "13306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: testdb
+      MYSQL_USER: testuser
+      MYSQL_PASSWORD: testpassword
+    healthcheck:
+      test: [
+        "CMD",
+        "mysqladmin",
+        "ping",
+        "-h",
+        "localhost",
+        "-u",
+        "root",
+        "-prootpassword",
+      ]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,6 +5,7 @@
     "./packages/probitas-client-grpc",
     "./packages/probitas-client-http",
     "./packages/probitas-client-sql",
+    "./packages/probitas-client-sql-mysql",
     "./packages/probitas-client-sql-postgres"
   ],
   "exclude": [
@@ -28,6 +29,7 @@
     "jsr:@probitas/client-grpc@^0": "./packages/probitas-client-grpc/mod.ts",
     "jsr:@probitas/client-http@^0": "./packages/probitas-client-http/mod.ts",
     "jsr:@probitas/client-sql@^0": "./packages/probitas-client-sql/mod.ts",
+    "jsr:@probitas/client-sql-mysql@^0": "./packages/probitas-client-sql-mysql/mod.ts",
     "jsr:@probitas/client-sql-postgres@^0": "./packages/probitas-client-sql-postgres/mod.ts"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -19,7 +19,8 @@
     "npm:@grpc/proto-loader@0.7": "0.7.15",
     "npm:@types/node@*": "24.2.0",
     "npm:grpc-reflection-js@0.3": "0.3.0_@grpc+grpc-js@1.12.6",
-    "npm:postgres@3": "3.4.7"
+    "npm:mysql2@*": "3.15.3",
+    "npm:mysql2@^3.11.0": "3.15.3"
   },
   "jsr": {
     "@cspotcode/outdent@0.8.0": {
@@ -164,6 +165,9 @@
         "color-convert"
       ]
     },
+    "aws-ssl-profiles@1.1.2": {
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="
+    },
     "cliui@8.0.1": {
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": [
@@ -181,11 +185,20 @@
     "color-name@1.1.4": {
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "denque@2.1.0": {
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
+    },
     "emoji-regex@8.0.0": {
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "escalade@3.2.0": {
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
+    },
+    "generate-function@2.3.1": {
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": [
+        "is-property"
+      ]
     },
     "get-caller-file@2.0.5": {
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
@@ -204,8 +217,17 @@
         "protobufjs"
       ]
     },
+    "iconv-lite@0.7.0": {
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
     "is-fullwidth-code-point@3.0.0": {
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-property@1.0.2": {
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
     "lodash.camelcase@4.3.0": {
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
@@ -216,8 +238,31 @@
     "long@5.3.2": {
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
-    "postgres@3.4.7": {
-      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="
+    "lru-cache@7.18.3": {
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+    },
+    "lru.min@1.1.3": {
+      "integrity": "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q=="
+    },
+    "mysql2@3.15.3": {
+      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
+      "dependencies": [
+        "aws-ssl-profiles",
+        "denque",
+        "generate-function",
+        "iconv-lite",
+        "long",
+        "lru.min",
+        "named-placeholders",
+        "seq-queue",
+        "sqlstring"
+      ]
+    },
+    "named-placeholders@1.1.3": {
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "dependencies": [
+        "lru-cache"
+      ]
     },
     "protobufjs@7.5.4": {
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
@@ -239,6 +284,15 @@
     },
     "require-directory@2.1.1": {
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "seq-queue@0.0.5": {
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "sqlstring@2.3.3": {
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
     },
     "string-width@4.2.3": {
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -318,6 +372,13 @@
       "packages/probitas-client-sql": {
         "dependencies": [
           "jsr:@probitas/client@0"
+        ]
+      },
+      "packages/probitas-client-sql-mysql": {
+        "dependencies": [
+          "jsr:@probitas/client-sql@0",
+          "jsr:@probitas/client@0",
+          "npm:mysql2@^3.11.0"
         ]
       },
       "packages/probitas-client-sql-postgres": {

--- a/packages/probitas-client-sql-mysql/client.ts
+++ b/packages/probitas-client-sql-mysql/client.ts
@@ -1,0 +1,261 @@
+import mysql from "mysql2/promise";
+import {
+  SqlQueryResult,
+  type SqlTransaction,
+  type SqlTransactionOptions,
+} from "@probitas/client-sql";
+import type { MySqlClientConfig, MySqlConnectionConfig } from "./types.ts";
+import { convertMySqlError } from "./errors.ts";
+import { MySqlTransactionImpl } from "./transaction.ts";
+import type { MySqlTransaction } from "./transaction.ts";
+
+/**
+ * MySQL client interface.
+ */
+export interface MySqlClient extends AsyncDisposable {
+  /** The client configuration. */
+  readonly config: MySqlClientConfig;
+
+  /** The SQL dialect identifier. */
+  readonly dialect: "mysql";
+
+  /**
+   * Execute a SQL query.
+   * @param sql - SQL query string
+   * @param params - Optional query parameters
+   */
+  // deno-lint-ignore no-explicit-any
+  query<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>>;
+
+  /**
+   * Execute a query and return the first row or undefined.
+   * @param sql - SQL query string
+   * @param params - Optional query parameters
+   */
+  // deno-lint-ignore no-explicit-any
+  queryOne<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined>;
+
+  /**
+   * Execute a function within a transaction.
+   * Automatically commits on success or rolls back on error.
+   * @param fn - Function to execute within transaction
+   * @param options - Transaction options
+   */
+  transaction<T>(
+    fn: (tx: SqlTransaction) => Promise<T>,
+    options?: SqlTransactionOptions,
+  ): Promise<T>;
+
+  /**
+   * Close the client and release all connections.
+   */
+  close(): Promise<void>;
+}
+
+/**
+ * Parse a MySQL connection URL into connection config.
+ * Supports format: mysql://user:password@host:port/database
+ */
+function parseConnectionUrl(url: string): MySqlConnectionConfig {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "mysql:") {
+    throw new Error(`Unsupported protocol: ${parsed.protocol}`);
+  }
+
+  return {
+    host: parsed.hostname,
+    port: parsed.port ? parseInt(parsed.port, 10) : undefined,
+    user: decodeURIComponent(parsed.username),
+    password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
+    database: parsed.pathname.slice(1), // Remove leading "/"
+  };
+}
+
+/**
+ * Create a MySQL client with connection pooling.
+ *
+ * @example
+ * ```typescript
+ * // Using connection URL
+ * const client = await createMySqlClient({
+ *   connection: "mysql://user:password@localhost:3306/testdb",
+ * });
+ *
+ * // Using connection config object
+ * const client = await createMySqlClient({
+ *   connection: {
+ *     host: "localhost",
+ *     port: 3306,
+ *     user: "root",
+ *     password: "password",
+ *     database: "testdb",
+ *   },
+ * });
+ *
+ * const result = await client.query<{ id: number; name: string }>(
+ *   "SELECT * FROM users WHERE id = ?",
+ *   [1],
+ * );
+ *
+ * console.log(result.rows.first()); // { id: 1, name: "Alice" }
+ *
+ * await client.close();
+ * ```
+ */
+export async function createMySqlClient(
+  config: MySqlClientConfig,
+): Promise<MySqlClient> {
+  const connConfig = typeof config.connection === "string"
+    ? parseConnectionUrl(config.connection)
+    : config.connection;
+
+  const poolConfig: mysql.PoolOptions = {
+    host: connConfig.host,
+    port: connConfig.port ?? 3306,
+    user: connConfig.user,
+    password: connConfig.password,
+    database: connConfig.database,
+    charset: config.charset,
+    timezone: config.timezone,
+    waitForConnections: config.pool?.waitForConnections ?? true,
+    connectionLimit: config.pool?.connectionLimit ?? 10,
+    queueLimit: config.pool?.queueLimit ?? 0,
+    idleTimeout: config.pool?.idleTimeout ?? 10000,
+    enableKeepAlive: true,
+    multipleStatements: connConfig.multipleStatements ?? false,
+  };
+
+  if (connConfig.tls) {
+    poolConfig.ssl = {
+      ca: connConfig.tls.ca,
+      cert: connConfig.tls.cert,
+      key: connConfig.tls.key,
+      rejectUnauthorized: connConfig.tls.rejectUnauthorized ?? true,
+    };
+  }
+
+  let pool: mysql.Pool;
+  try {
+    pool = mysql.createPool(poolConfig);
+    // Test connection
+    const connection = await pool.getConnection();
+    connection.release();
+  } catch (error) {
+    throw convertMySqlError(error);
+  }
+
+  return new MySqlClientImpl(config, pool);
+}
+
+class MySqlClientImpl implements MySqlClient {
+  readonly config: MySqlClientConfig;
+  readonly dialect = "mysql" as const;
+  readonly #pool: mysql.Pool;
+  #closed = false;
+
+  constructor(config: MySqlClientConfig, pool: mysql.Pool) {
+    this.config = config;
+    this.#pool = pool;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async query<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>> {
+    if (this.#closed) {
+      throw convertMySqlError(new Error("Client is closed"));
+    }
+
+    const startTime = performance.now();
+
+    try {
+      // deno-lint-ignore no-explicit-any
+      const [rows, fields] = await (this.#pool as any).execute(sql, params);
+      const duration = performance.now() - startTime;
+
+      // Handle SELECT queries
+      if (Array.isArray(rows)) {
+        return new SqlQueryResult<T>({
+          ok: true,
+          rows: rows as unknown as T[],
+          rowCount: rows.length,
+          duration,
+          metadata: {
+            warnings: fields ? undefined : undefined,
+          },
+        });
+      }
+
+      // Handle INSERT/UPDATE/DELETE queries (ResultSetHeader)
+      // deno-lint-ignore no-explicit-any
+      const resultHeader = rows as any;
+      return new SqlQueryResult<T>({
+        ok: true,
+        rows: [],
+        rowCount: resultHeader.affectedRows,
+        duration,
+        metadata: {
+          lastInsertId: resultHeader.insertId
+            ? BigInt(resultHeader.insertId)
+            : undefined,
+          warnings: resultHeader.warningStatus > 0
+            ? [`${resultHeader.warningStatus} warning(s)`]
+            : undefined,
+        },
+      });
+    } catch (error) {
+      throw convertMySqlError(error);
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async queryOne<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined> {
+    const result = await this.query<T>(sql, params);
+    return result.rows.first();
+  }
+
+  async transaction<T>(
+    fn: (tx: SqlTransaction) => Promise<T>,
+    options?: SqlTransactionOptions,
+  ): Promise<T> {
+    if (this.#closed) {
+      throw convertMySqlError(new Error("Client is closed"));
+    }
+
+    let tx: MySqlTransaction;
+    try {
+      const connection = await this.#pool.getConnection();
+      tx = await MySqlTransactionImpl.begin(connection, options);
+    } catch (error) {
+      throw convertMySqlError(error);
+    }
+    try {
+      const result = await fn(tx);
+      await tx.commit();
+      return result;
+    } catch (error) {
+      await tx.rollback();
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    await this.#pool.end();
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close();
+  }
+}

--- a/packages/probitas-client-sql-mysql/deno.json
+++ b/packages/probitas-client-sql-mysql/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@probitas/client-sql-mysql",
+  "version": "0.0.0",
+  "exports": "./mod.ts",
+  "publish": {
+    "exclude": ["**/*_test.ts", "**/*_bench.ts"]
+  },
+  "imports": {
+    "@probitas/client": "jsr:@probitas/client@^0",
+    "@probitas/client-sql": "jsr:@probitas/client-sql@^0",
+    "mysql2": "npm:mysql2@^3.11.0"
+  }
+}

--- a/packages/probitas-client-sql-mysql/errors.ts
+++ b/packages/probitas-client-sql-mysql/errors.ts
@@ -1,0 +1,127 @@
+import {
+  ConstraintError,
+  DeadlockError,
+  QuerySyntaxError,
+  SqlError,
+  type SqlErrorOptions,
+} from "@probitas/client-sql";
+
+/**
+ * MySQL-specific error kinds.
+ */
+export type MySqlErrorKind = "access_denied" | "connection_refused";
+
+/**
+ * Options for MySqlError constructor.
+ */
+export interface MySqlErrorOptions extends SqlErrorOptions {
+  /** MySQL error code (e.g., 1045, 1062). */
+  readonly errno?: number;
+}
+
+/**
+ * Base error class for MySQL-specific errors.
+ * Extends SqlError with MySQL-specific properties like errno.
+ */
+export class MySqlError extends SqlError {
+  override readonly name: string = "MySqlError";
+  readonly errno?: number;
+
+  constructor(
+    message: string,
+    options?: MySqlErrorOptions,
+  ) {
+    super(message, "unknown", options);
+    this.errno = options?.errno;
+  }
+}
+
+/**
+ * Error thrown when access is denied (wrong credentials).
+ */
+export class AccessDeniedError extends MySqlError {
+  override readonly name = "AccessDeniedError";
+  readonly mysqlKind = "access_denied" as const;
+
+  constructor(message: string, options?: MySqlErrorOptions) {
+    super(message, options);
+  }
+}
+
+/**
+ * Error thrown when connection is refused.
+ */
+export class ConnectionRefusedError extends MySqlError {
+  override readonly name = "ConnectionRefusedError";
+  readonly mysqlKind = "connection_refused" as const;
+
+  constructor(message: string, options?: MySqlErrorOptions) {
+    super(message, options);
+  }
+}
+
+// MySQL Error Codes
+// See: https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+const ER_ACCESS_DENIED_ERROR = 1045;
+const ER_DUP_ENTRY = 1062;
+const ER_NO_REFERENCED_ROW_2 = 1452;
+const ER_ROW_IS_REFERENCED_2 = 1451;
+const ER_LOCK_DEADLOCK = 1213;
+const ER_PARSE_ERROR = 1064;
+const ER_CHECK_CONSTRAINT_VIOLATED = 3819;
+
+/**
+ * Convert a mysql2 error to the appropriate error class.
+ */
+export function convertMySqlError(error: unknown): SqlError {
+  if (!(error instanceof Error)) {
+    return new MySqlError(String(error));
+  }
+
+  // mysql2 errors have errno and sqlState properties
+  const err = error as Error & {
+    errno?: number;
+    sqlState?: string;
+    code?: string;
+  };
+
+  const options: MySqlErrorOptions = {
+    cause: error,
+    errno: err.errno,
+    sqlState: err.sqlState,
+  };
+
+  // Check for connection errors first
+  if (err.code === "ECONNREFUSED") {
+    return new ConnectionRefusedError(err.message, options);
+  }
+
+  if (err.errno === ER_ACCESS_DENIED_ERROR) {
+    return new AccessDeniedError(err.message, options);
+  }
+
+  if (err.errno === ER_PARSE_ERROR) {
+    return new QuerySyntaxError(err.message, options);
+  }
+
+  if (
+    err.errno === ER_DUP_ENTRY ||
+    err.errno === ER_NO_REFERENCED_ROW_2 ||
+    err.errno === ER_ROW_IS_REFERENCED_2 ||
+    err.errno === ER_CHECK_CONSTRAINT_VIOLATED
+  ) {
+    // Extract constraint name from error message if possible
+    const constraintMatch = err.message.match(
+      /for key '([^']+)'|CONSTRAINT `([^`]+)`/,
+    );
+    const constraint = constraintMatch?.[1] ?? constraintMatch?.[2] ??
+      "unknown";
+    return new ConstraintError(err.message, constraint, options);
+  }
+
+  if (err.errno === ER_LOCK_DEADLOCK) {
+    return new DeadlockError(err.message, options);
+  }
+
+  return new MySqlError(err.message, options);
+}

--- a/packages/probitas-client-sql-mysql/errors_test.ts
+++ b/packages/probitas-client-sql-mysql/errors_test.ts
@@ -1,0 +1,151 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { SqlError } from "@probitas/client-sql";
+import {
+  AccessDeniedError,
+  ConnectionRefusedError,
+  convertMySqlError,
+  MySqlError,
+} from "./errors.ts";
+
+Deno.test("MySqlError", async (t) => {
+  await t.step("extends SqlError", () => {
+    const error = new MySqlError("test error");
+    assertInstanceOf(error, SqlError);
+    assertInstanceOf(error, Error);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new MySqlError("test error", {
+      errno: 1064,
+      sqlState: "42000",
+    });
+
+    assertEquals(error.name, "MySqlError");
+    assertEquals(error.message, "test error");
+    assertEquals(error.kind, "unknown");
+    assertEquals(error.errno, 1064);
+    assertEquals(error.sqlState, "42000");
+  });
+
+  await t.step("supports error chaining", () => {
+    const cause = new Error("original error");
+    const error = new MySqlError("wrapped", { cause });
+
+    assertEquals(error.cause, cause);
+  });
+});
+
+Deno.test("AccessDeniedError", async (t) => {
+  await t.step("extends MySqlError with access_denied mysqlKind", () => {
+    const error = new AccessDeniedError("Access denied for user", {
+      errno: 1045,
+    });
+
+    assertInstanceOf(error, MySqlError);
+    assertEquals(error.name, "AccessDeniedError");
+    assertEquals(error.mysqlKind, "access_denied");
+    assertEquals(error.errno, 1045);
+  });
+});
+
+Deno.test("ConnectionRefusedError", async (t) => {
+  await t.step("extends MySqlError with connection_refused mysqlKind", () => {
+    const error = new ConnectionRefusedError("Connection refused");
+
+    assertInstanceOf(error, MySqlError);
+    assertEquals(error.name, "ConnectionRefusedError");
+    assertEquals(error.mysqlKind, "connection_refused");
+  });
+});
+
+Deno.test("convertMySqlError", async (t) => {
+  await t.step("handles non-Error values", () => {
+    const error = convertMySqlError("string error");
+
+    assertInstanceOf(error, MySqlError);
+    assertEquals(error.message, "string error");
+    assertEquals(error.kind, "unknown");
+  });
+
+  await t.step("converts ECONNREFUSED to ConnectionRefusedError", () => {
+    const mysqlError = Object.assign(new Error("Connection refused"), {
+      code: "ECONNREFUSED",
+    });
+
+    const error = convertMySqlError(mysqlError);
+
+    assertInstanceOf(error, ConnectionRefusedError);
+    assertEquals(
+      (error as ConnectionRefusedError).mysqlKind,
+      "connection_refused",
+    );
+  });
+
+  await t.step("converts errno 1045 to AccessDeniedError", () => {
+    const mysqlError = Object.assign(
+      new Error("Access denied for user 'root'@'localhost'"),
+      {
+        errno: 1045,
+        sqlState: "28000",
+      },
+    );
+
+    const error = convertMySqlError(mysqlError);
+
+    assertInstanceOf(error, AccessDeniedError);
+    assertEquals((error as AccessDeniedError).mysqlKind, "access_denied");
+  });
+
+  await t.step("converts errno 1064 to QuerySyntaxError", () => {
+    const mysqlError = Object.assign(
+      new Error("You have an error in your SQL syntax"),
+      {
+        errno: 1064,
+        sqlState: "42000",
+      },
+    );
+
+    const error = convertMySqlError(mysqlError);
+
+    assertEquals(error.kind, "query");
+  });
+
+  await t.step("converts errno 1062 to ConstraintError", () => {
+    const mysqlError = Object.assign(
+      new Error("Duplicate entry 'foo' for key 'PRIMARY'"),
+      {
+        errno: 1062,
+        sqlState: "23000",
+      },
+    );
+
+    const error = convertMySqlError(mysqlError);
+
+    assertEquals(error.kind, "constraint");
+  });
+
+  await t.step("converts errno 1213 to DeadlockError", () => {
+    const mysqlError = Object.assign(
+      new Error("Deadlock found when trying to get lock"),
+      {
+        errno: 1213,
+        sqlState: "40001",
+      },
+    );
+
+    const error = convertMySqlError(mysqlError);
+
+    assertEquals(error.kind, "deadlock");
+  });
+
+  await t.step("preserves cause in converted error", () => {
+    const originalError = Object.assign(new Error("Original"), {
+      errno: 1064,
+      sqlState: "42000",
+    });
+
+    const error = convertMySqlError(originalError);
+
+    assertEquals(error.cause, originalError);
+  });
+});

--- a/packages/probitas-client-sql-mysql/integration_test.ts
+++ b/packages/probitas-client-sql-mysql/integration_test.ts
@@ -1,0 +1,315 @@
+/**
+ * Integration tests for MySqlClient.
+ *
+ * Run with:
+ *   docker compose up -d mysql
+ *   deno test -A packages/probitas-client-sql-mysql/integration_test.ts
+ *   docker compose down
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { createMySqlClient, type MySqlClient } from "./client.ts";
+import { expectSqlQueryResult } from "@probitas/client-sql";
+import type { MySqlConnectionConfig } from "./types.ts";
+
+const MYSQL_HOST = Deno.env.get("MYSQL_HOST") ?? "localhost";
+const MYSQL_PORT = parseInt(Deno.env.get("MYSQL_PORT") ?? "13306", 10);
+const MYSQL_USER = Deno.env.get("MYSQL_USER") ?? "testuser";
+const MYSQL_PASSWORD = Deno.env.get("MYSQL_PASSWORD") ?? "testpassword";
+const MYSQL_DATABASE = Deno.env.get("MYSQL_DATABASE") ?? "testdb";
+
+const connectionConfig: MySqlConnectionConfig = {
+  host: MYSQL_HOST,
+  port: MYSQL_PORT,
+  user: MYSQL_USER,
+  password: MYSQL_PASSWORD,
+  database: MYSQL_DATABASE,
+};
+
+async function isMySqlServerAvailable(): Promise<boolean> {
+  try {
+    const conn = await Deno.connect({
+      hostname: MYSQL_HOST,
+      port: MYSQL_PORT,
+    });
+    conn.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createTestClient(): Promise<MySqlClient> {
+  return await createMySqlClient({ connection: connectionConfig });
+}
+
+Deno.test({
+  name: "Integration: MySQL",
+  ignore: !(await isMySqlServerAvailable()),
+  async fn(t) {
+    await t.step("basic query - SELECT 1", async () => {
+      const client = await createTestClient();
+
+      try {
+        const result = await client.query<{ result: number }>(
+          "SELECT 1 as result",
+        );
+
+        expectSqlQueryResult(result)
+          .ok()
+          .rows(1);
+
+        assertEquals(result.rows.first()?.result, 1);
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("dialect property", async () => {
+      await using client = await createTestClient();
+      assertEquals(client.dialect, "mysql");
+    });
+
+    await t.step("connection URL format", async () => {
+      const url =
+        `mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}`;
+      await using client = await createMySqlClient({ connection: url });
+
+      const result = await client.query<{ result: number }>(
+        "SELECT 1 as result",
+      );
+
+      expectSqlQueryResult(result)
+        .ok()
+        .rows(1);
+    });
+
+    await t.step("using with statement (AsyncDisposable)", async () => {
+      await using client = await createTestClient();
+
+      const result = await client.query<{ now: Date }>("SELECT NOW() as now");
+
+      expectSqlQueryResult(result)
+        .ok()
+        .rows(1);
+    });
+
+    await t.step("parameterized query", async () => {
+      await using client = await createTestClient();
+
+      const result = await client.query<{ sum: number }>(
+        "SELECT ? + ? as sum",
+        [10, 20],
+      );
+
+      expectSqlQueryResult(result)
+        .ok()
+        .rows(1);
+
+      assertEquals(result.rows.first()?.sum, 30);
+    });
+
+    await t.step("queryOne returns first row", async () => {
+      await using client = await createTestClient();
+
+      const row = await client.queryOne<{ value: string }>(
+        "SELECT 'hello' as value",
+      );
+
+      assertEquals(row?.value, "hello");
+    });
+
+    await t.step("queryOne returns undefined for no results", async () => {
+      await using client = await createTestClient();
+
+      const row = await client.queryOne<{ value: number }>(
+        "SELECT * FROM (SELECT 1 as value) t WHERE value = 0",
+      );
+
+      assertEquals(row, undefined);
+    });
+
+    await t.step("CREATE TABLE, INSERT, SELECT, DROP", async () => {
+      await using client = await createTestClient();
+
+      // Create table
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS test_users (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          name VARCHAR(100) NOT NULL,
+          email VARCHAR(255) UNIQUE
+        )
+      `);
+
+      try {
+        // Insert
+        const insertResult = await client.query(
+          "INSERT INTO test_users (name, email) VALUES (?, ?)",
+          ["Alice", "alice@example.com"],
+        );
+
+        expectSqlQueryResult(insertResult)
+          .ok()
+          .rowCount(1)
+          .hasLastInsertId();
+
+        // Select
+        const selectResult = await client.query<{
+          id: number;
+          name: string;
+          email: string;
+        }>(
+          "SELECT * FROM test_users WHERE name = ?",
+          ["Alice"],
+        );
+
+        expectSqlQueryResult(selectResult)
+          .ok()
+          .rows(1);
+
+        assertEquals(selectResult.rows.first()?.name, "Alice");
+        assertEquals(selectResult.rows.first()?.email, "alice@example.com");
+      } finally {
+        // Drop table
+        await client.query("DROP TABLE IF EXISTS test_users");
+      }
+    });
+
+    await t.step("transaction helper with auto-commit", async () => {
+      await using client = await createTestClient();
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS test_tx_helper (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          value VARCHAR(100)
+        )
+      `);
+
+      try {
+        const lastInsertId = await client.transaction(async (tx) => {
+          const result = await tx.query(
+            "INSERT INTO test_tx_helper (value) VALUES (?)",
+            ["auto-committed"],
+          );
+          return result.metadata.lastInsertId;
+        });
+
+        assertEquals(typeof lastInsertId, "bigint");
+
+        const result = await client.query<{ value: string }>(
+          "SELECT value FROM test_tx_helper WHERE id = ?",
+          [lastInsertId],
+        );
+
+        expectSqlQueryResult(result)
+          .ok()
+          .rows(1);
+
+        assertEquals(result.rows.first()?.value, "auto-committed");
+      } finally {
+        await client.query("DROP TABLE IF EXISTS test_tx_helper");
+      }
+    });
+
+    await t.step("transaction helper with auto-rollback on error", async () => {
+      await using client = await createTestClient();
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS test_tx_error (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          value VARCHAR(100)
+        )
+      `);
+
+      try {
+        await assertRejects(
+          async () => {
+            await client.transaction(async (tx) => {
+              await tx.query("INSERT INTO test_tx_error (value) VALUES (?)", [
+                "will-rollback",
+              ]);
+              throw new Error("Intentional error");
+            });
+          },
+          Error,
+          "Intentional error",
+        );
+
+        const result = await client.query<{ value: string }>(
+          "SELECT value FROM test_tx_error WHERE value = ?",
+          ["will-rollback"],
+        );
+
+        expectSqlQueryResult(result)
+          .ok()
+          .rows(0);
+      } finally {
+        await client.query("DROP TABLE IF EXISTS test_tx_error");
+      }
+    });
+
+    await t.step("transaction with isolation level", async () => {
+      await using client = await createTestClient();
+
+      await client.transaction(async (tx) => {
+        const result = await tx.query<{ level: string }>(
+          "SELECT @@transaction_isolation as level",
+        );
+
+        assertEquals(result.rows.first()?.level, "SERIALIZABLE");
+      }, { isolationLevel: "serializable" });
+    });
+
+    await t.step("result metadata - lastInsertId", async () => {
+      await using client = await createTestClient();
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS test_insert_id (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          value VARCHAR(100)
+        )
+      `);
+
+      try {
+        const result = await client.query(
+          "INSERT INTO test_insert_id (value) VALUES (?)",
+          ["test"],
+        );
+
+        expectSqlQueryResult(result)
+          .ok()
+          .rowCount(1)
+          .hasLastInsertId();
+
+        assertEquals(typeof result.metadata.lastInsertId, "bigint");
+      } finally {
+        await client.query("DROP TABLE IF EXISTS test_insert_id");
+      }
+    });
+
+    await t.step("result transformation - map()", async () => {
+      await using client = await createTestClient();
+
+      const result = await client.query<{ n: number }>(
+        "SELECT 1 as n UNION SELECT 2 UNION SELECT 3",
+      );
+
+      const doubled = result.map((row) => row.n * 2);
+
+      assertEquals(doubled.sort(), [2, 4, 6]);
+    });
+
+    await t.step("duration tracking", async () => {
+      await using client = await createTestClient();
+
+      const result = await client.query("SELECT SLEEP(0.1)");
+
+      expectSqlQueryResult(result)
+        .ok()
+        .durationLessThan(1000);
+
+      // Should take at least 100ms due to SLEEP
+      assertEquals(result.duration >= 100, true);
+    });
+  },
+});

--- a/packages/probitas-client-sql-mysql/mod.ts
+++ b/packages/probitas-client-sql-mysql/mod.ts
@@ -1,0 +1,14 @@
+// Client
+export * from "./client.ts";
+
+// Transaction
+export type * from "./transaction.ts";
+
+// Types
+export type * from "./types.ts";
+
+// Errors
+export * from "./errors.ts";
+
+// Re-export common types from @probitas/client-sql
+export * from "@probitas/client-sql";

--- a/packages/probitas-client-sql-mysql/transaction.ts
+++ b/packages/probitas-client-sql-mysql/transaction.ts
@@ -1,0 +1,213 @@
+import type mysql from "mysql2/promise";
+import {
+  type SqlIsolationLevel,
+  SqlQueryResult,
+  type SqlTransaction,
+  type SqlTransactionOptions,
+} from "@probitas/client-sql";
+import { convertMySqlError } from "./errors.ts";
+
+/**
+ * MySQL-specific transaction interface.
+ * Extends SqlTransaction with MySQL-specific features.
+ */
+export interface MySqlTransaction extends SqlTransaction {
+  /**
+   * Create a savepoint.
+   * @param name - Savepoint name
+   */
+  savepoint(name: string): Promise<void>;
+
+  /**
+   * Rollback to a savepoint.
+   * @param name - Savepoint name
+   */
+  rollbackToSavepoint(name: string): Promise<void>;
+
+  /**
+   * Release a savepoint.
+   * @param name - Savepoint name
+   */
+  releaseSavepoint(name: string): Promise<void>;
+}
+
+const ISOLATION_LEVEL_MAP: Record<SqlIsolationLevel, string> = {
+  read_uncommitted: "READ UNCOMMITTED",
+  read_committed: "READ COMMITTED",
+  repeatable_read: "REPEATABLE READ",
+  serializable: "SERIALIZABLE",
+};
+
+// deno-lint-ignore no-explicit-any
+type AnyPoolConnection = mysql.PoolConnection | any;
+
+export class MySqlTransactionImpl implements MySqlTransaction {
+  readonly #connection: AnyPoolConnection;
+  #finished = false;
+
+  private constructor(connection: AnyPoolConnection) {
+    this.#connection = connection;
+  }
+
+  /**
+   * Begin a new transaction.
+   */
+  static async begin(
+    connection: AnyPoolConnection,
+    options?: SqlTransactionOptions,
+  ): Promise<MySqlTransactionImpl> {
+    try {
+      if (options?.isolationLevel) {
+        const level = ISOLATION_LEVEL_MAP[options.isolationLevel];
+        // Use SESSION to ensure isolation level applies to the current connection
+        await connection.execute(
+          `SET SESSION TRANSACTION ISOLATION LEVEL ${level}`,
+        );
+      }
+      await connection.beginTransaction();
+      return new MySqlTransactionImpl(connection);
+    } catch (error) {
+      connection.release();
+      throw convertMySqlError(error);
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async query<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>> {
+    if (this.#finished) {
+      throw convertMySqlError(new Error("Transaction is already finished"));
+    }
+
+    const startTime = performance.now();
+
+    try {
+      const [rows, _fields] = await this.#connection.execute(sql, params);
+      const duration = performance.now() - startTime;
+
+      // Handle SELECT queries
+      if (Array.isArray(rows)) {
+        return new SqlQueryResult<T>({
+          ok: true,
+          rows: rows as unknown as T[],
+          rowCount: rows.length,
+          duration,
+          metadata: {},
+        });
+      }
+
+      // Handle INSERT/UPDATE/DELETE queries (ResultSetHeader)
+      // deno-lint-ignore no-explicit-any
+      const resultHeader = rows as any;
+      return new SqlQueryResult<T>({
+        ok: true,
+        rows: [],
+        rowCount: resultHeader.affectedRows,
+        duration,
+        metadata: {
+          lastInsertId: resultHeader.insertId
+            ? BigInt(resultHeader.insertId)
+            : undefined,
+          warnings: resultHeader.warningStatus > 0
+            ? [`${resultHeader.warningStatus} warning(s)`]
+            : undefined,
+        },
+      });
+    } catch (error) {
+      throw convertMySqlError(error);
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async queryOne<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined> {
+    const result = await this.query<T>(sql, params);
+    return result.rows.first();
+  }
+
+  async commit(): Promise<void> {
+    if (this.#finished) {
+      throw convertMySqlError(new Error("Transaction is already finished"));
+    }
+
+    try {
+      await this.#connection.commit();
+    } catch (error) {
+      throw convertMySqlError(error);
+    } finally {
+      this.#finished = true;
+      this.#connection.release();
+    }
+  }
+
+  async rollback(): Promise<void> {
+    if (this.#finished) {
+      throw convertMySqlError(new Error("Transaction is already finished"));
+    }
+
+    try {
+      await this.#connection.rollback();
+    } catch (error) {
+      throw convertMySqlError(error);
+    } finally {
+      this.#finished = true;
+      this.#connection.release();
+    }
+  }
+
+  async savepoint(name: string): Promise<void> {
+    if (this.#finished) {
+      throw convertMySqlError(new Error("Transaction is already finished"));
+    }
+
+    try {
+      // Use query instead of execute - SAVEPOINT doesn't support prepared statements
+      await this.#connection.query(`SAVEPOINT ${this.#escapeName(name)}`);
+    } catch (error) {
+      throw convertMySqlError(error);
+    }
+  }
+
+  async rollbackToSavepoint(name: string): Promise<void> {
+    if (this.#finished) {
+      throw convertMySqlError(new Error("Transaction is already finished"));
+    }
+
+    try {
+      // Use query instead of execute - ROLLBACK TO doesn't support prepared statements
+      await this.#connection.query(
+        `ROLLBACK TO SAVEPOINT ${this.#escapeName(name)}`,
+      );
+    } catch (error) {
+      throw convertMySqlError(error);
+    }
+  }
+
+  async releaseSavepoint(name: string): Promise<void> {
+    if (this.#finished) {
+      throw convertMySqlError(new Error("Transaction is already finished"));
+    }
+
+    try {
+      // Use query instead of execute - RELEASE SAVEPOINT doesn't support prepared statements
+      await this.#connection.query(
+        `RELEASE SAVEPOINT ${this.#escapeName(name)}`,
+      );
+    } catch (error) {
+      throw convertMySqlError(error);
+    }
+  }
+
+  #escapeName(name: string): string {
+    // Simple identifier escaping for savepoint names
+    // MySQL allows alphanumeric and underscore in identifiers
+    if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+      throw new Error(`Invalid savepoint name: ${name}`);
+    }
+    return name;
+  }
+}

--- a/packages/probitas-client-sql-mysql/types.ts
+++ b/packages/probitas-client-sql-mysql/types.ts
@@ -1,0 +1,103 @@
+import type { CommonOptions } from "@probitas/client";
+
+/**
+ * TLS/SSL configuration for MySQL connections.
+ */
+export interface MySqlTlsConfig {
+  /** Root CA certificate (PEM format). */
+  readonly ca?: string;
+  /** Client certificate (PEM format). */
+  readonly cert?: string;
+  /** Client private key (PEM format). */
+  readonly key?: string;
+  /** Skip server certificate verification (use only for testing). */
+  readonly rejectUnauthorized?: boolean;
+}
+
+/**
+ * Connection pool configuration.
+ */
+export interface MySqlPoolConfig {
+  /**
+   * Maximum number of connections in the pool.
+   * @default 10
+   */
+  readonly connectionLimit?: number;
+
+  /**
+   * Minimum number of idle connections.
+   * @default 0
+   */
+  readonly minConnections?: number;
+
+  /**
+   * Maximum number of connection requests the pool will queue.
+   * @default 0 (unlimited)
+   */
+  readonly queueLimit?: number;
+
+  /**
+   * Whether to wait for connections to become available.
+   * @default true
+   */
+  readonly waitForConnections?: boolean;
+
+  /**
+   * Time in milliseconds before connection is considered idle.
+   * @default 10000
+   */
+  readonly idleTimeout?: number;
+}
+
+/**
+ * Detailed connection configuration for MySQL.
+ */
+export interface MySqlConnectionConfig {
+  /** MySQL server hostname. */
+  readonly host: string;
+
+  /**
+   * MySQL server port.
+   * @default 3306
+   */
+  readonly port?: number;
+
+  /** Database user. */
+  readonly user: string;
+
+  /** Database password. */
+  readonly password?: string;
+
+  /** Database name. */
+  readonly database: string;
+
+  /** TLS/SSL configuration. */
+  readonly tls?: MySqlTlsConfig;
+
+  /**
+   * Enable multiple statements in a single query.
+   * @default false
+   */
+  readonly multipleStatements?: boolean;
+}
+
+/**
+ * Configuration for creating a MySQL client.
+ */
+export interface MySqlClientConfig extends CommonOptions {
+  /**
+   * Connection configuration.
+   * Can be a connection URL string (e.g., "mysql://user:pass@host:port/database")
+   * or a detailed ConnectionConfig object.
+   */
+  readonly connection: string | MySqlConnectionConfig;
+
+  /** Connection pool configuration. */
+  readonly pool?: MySqlPoolConfig;
+
+  /** Character set for the connection. */
+  readonly charset?: string;
+
+  /** Timezone for the connection. */
+  readonly timezone?: string;
+}


### PR DESCRIPTION
## Summary
- Add `@probitas/client-sql-mysql` package for MySQL database connectivity
- Implement MySqlClient with connection pooling via `mysql2/promise`
- Add CI integration tests with MySQL service

## Features
- **Connection**: Support both URL (`mysql://user:pass@host/db`) and object config
- **Queries**: `query<T>()`, `queryOne<T>()` with parameterized SQL
- **Transactions**: `transaction<T>(fn)` with auto-commit/rollback and isolation levels
- **MySQL Extensions**: Savepoint support (`savepoint()`, `rollbackToSavepoint()`, `releaseSavepoint()`)
- **Error Handling**: `AccessDeniedError`, `ConnectionRefusedError`, `ConstraintError`, `DeadlockError`, `QuerySyntaxError`

## API
```typescript
const client = await createMySqlClient({
  connection: "mysql://user:pass@localhost:3306/db",
});

const result = await client.query<User>("SELECT * FROM users WHERE id = ?", [1]);
await client.transaction(async (tx) => {
  await tx.query("INSERT INTO users ...");
});
await client.close();
```

## Test plan
- [x] Unit tests for error conversion (`errors_test.ts`)
- [x] Integration tests with real MySQL (`integration_test.ts`)
- [x] CI workflow updated with MySQL service
- [x] All existing tests pass (94 tests)