### PR TITLE
feat: Add spec compliance for @probitas/client-graphql

### DIFF
--- a/packages/probitas-client-graphql/client.ts
+++ b/packages/probitas-client-graphql/client.ts
@@ -62,6 +62,15 @@ class GraphqlClientImpl implements GraphqlClient {
   }
 
   // deno-lint-ignore no-explicit-any
+  mutate<TData = any, TVariables = Record<string, any>>(
+    mutation: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): Promise<GraphqlResponse<TData>> {
+    return this.mutation<TData, TVariables>(mutation, variables, options);
+  }
+
+  // deno-lint-ignore no-explicit-any
   async execute<TData = any, TVariables = Record<string, any>>(
     document: string,
     variables?: TVariables,
@@ -134,6 +143,165 @@ class GraphqlClientImpl implements GraphqlClient {
     }
 
     return response;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async *subscribe<TData = any, TVariables = Record<string, any>>(
+    document: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): AsyncIterable<GraphqlResponse<TData>> {
+    const wsEndpoint = this.config.wsEndpoint;
+    if (!wsEndpoint) {
+      throw new GraphqlNetworkError(
+        "WebSocket endpoint (wsEndpoint) is not configured",
+      );
+    }
+
+    const ws = new WebSocket(wsEndpoint, "graphql-ws");
+
+    // Wait for connection to open
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = (event) =>
+        reject(
+          new GraphqlNetworkError(
+            `WebSocket connection failed: ${
+              (event as ErrorEvent).message ?? "unknown error"
+            }`,
+          ),
+        );
+    });
+
+    // Send connection_init message
+    ws.send(JSON.stringify({ type: "connection_init" }));
+
+    // Wait for connection_ack
+    await new Promise<void>((resolve, reject) => {
+      const handler = (event: MessageEvent) => {
+        const message = JSON.parse(event.data);
+        if (message.type === "connection_ack") {
+          ws.removeEventListener("message", handler);
+          resolve();
+        } else if (message.type === "connection_error") {
+          ws.removeEventListener("message", handler);
+          reject(
+            new GraphqlNetworkError(
+              `WebSocket connection error: ${JSON.stringify(message.payload)}`,
+            ),
+          );
+        }
+      };
+      ws.addEventListener("message", handler);
+    });
+
+    // Generate a unique subscription ID
+    const subscriptionId = crypto.randomUUID();
+
+    // Send start/subscribe message
+    ws.send(
+      JSON.stringify({
+        id: subscriptionId,
+        type: "subscribe",
+        payload: {
+          query: document,
+          variables: variables ?? undefined,
+          operationName: options?.operationName,
+        },
+      }),
+    );
+
+    // Create an async iterator to yield responses
+    const responseQueue: GraphqlResponse<TData>[] = [];
+    let resolveNext: (() => void) | null = null;
+    let done = false;
+    let error: Error | null = null;
+
+    const messageHandler = (event: MessageEvent) => {
+      const message = JSON.parse(event.data);
+
+      switch (message.type) {
+        case "next": {
+          const startTime = performance.now();
+          const payload = message.payload as GraphqlResponseBody<TData>;
+
+          const response = createGraphqlResponse<TData>({
+            data: payload.data ?? null,
+            errors: payload.errors ?? null,
+            extensions: payload.extensions,
+            duration: performance.now() - startTime,
+            status: 200,
+            raw: new Response(JSON.stringify(payload)),
+          });
+
+          responseQueue.push(response);
+          resolveNext?.();
+          break;
+        }
+        case "error": {
+          error = new GraphqlNetworkError(
+            `Subscription error: ${JSON.stringify(message.payload)}`,
+          );
+          done = true;
+          resolveNext?.();
+          break;
+        }
+        case "complete": {
+          done = true;
+          resolveNext?.();
+          break;
+        }
+      }
+    };
+
+    ws.addEventListener("message", messageHandler);
+
+    // Handle WebSocket close
+    ws.onclose = () => {
+      done = true;
+      resolveNext?.();
+    };
+
+    ws.onerror = () => {
+      error = new GraphqlNetworkError("WebSocket error during subscription");
+      done = true;
+      resolveNext?.();
+    };
+
+    try {
+      while (true) {
+        if (responseQueue.length > 0) {
+          const response = responseQueue.shift()!;
+
+          // Determine whether to throw on errors
+          const shouldThrow = options?.throwOnError ??
+            this.config.throwOnError ?? true;
+
+          if (!response.ok && shouldThrow && response.errors) {
+            throw new GraphqlExecutionError(response.errors, { response });
+          }
+
+          yield response;
+        } else if (done) {
+          if (error) {
+            throw error;
+          }
+          break;
+        } else {
+          await new Promise<void>((resolve) => {
+            resolveNext = resolve;
+          });
+          resolveNext = null;
+        }
+      }
+    } finally {
+      // Clean up: send stop message and close WebSocket
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ id: subscriptionId, type: "complete" }));
+        ws.close();
+      }
+      ws.removeEventListener("message", messageHandler);
+    }
   }
 
   close(): Promise<void> {

--- a/packages/probitas-client-graphql/expect_test.ts
+++ b/packages/probitas-client-graphql/expect_test.ts
@@ -355,3 +355,115 @@ Deno.test("expectGraphqlResponse.noData()", async (t) => {
     );
   });
 });
+
+Deno.test("expectGraphqlResponse.noErrors()", async (t) => {
+  await t.step("passes when no errors (alias for ok)", () => {
+    const response = createMockResponse({ data: { test: true }, errors: null });
+    expectGraphqlResponse(response).noErrors();
+  });
+
+  await t.step("passes when errors is empty array", () => {
+    const response = createMockResponse({ data: { test: true }, errors: [] });
+    expectGraphqlResponse(response).noErrors();
+  });
+
+  await t.step("throws when errors present", () => {
+    const response = createMockResponse({
+      errors: [{ message: "Error" }],
+    });
+    assertThrows(
+      () => expectGraphqlResponse(response).noErrors(),
+      Error,
+      "Expected ok response",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.error()", async (t) => {
+  await t.step("passes with string matcher when error contains message", () => {
+    const response = createMockResponse({
+      errors: [{ message: "User not found" }],
+    });
+    expectGraphqlResponse(response).error("not found");
+  });
+
+  await t.step("passes with RegExp matcher when error matches", () => {
+    const response = createMockResponse({
+      errors: [{ message: "User 123 not found" }],
+    });
+    expectGraphqlResponse(response).error(/User \d+ not found/);
+  });
+
+  await t.step("passes when any error matches RegExp", () => {
+    const response = createMockResponse({
+      errors: [
+        { message: "First error" },
+        { message: "User 456 not found" },
+      ],
+    });
+    expectGraphqlResponse(response).error(/User \d+ not found/);
+  });
+
+  await t.step("throws when no error matches string", () => {
+    const response = createMockResponse({
+      errors: [{ message: "Something else" }],
+    });
+    assertThrows(
+      () => expectGraphqlResponse(response).error("not found"),
+      Error,
+      'Expected an error matching "not found"',
+    );
+  });
+
+  await t.step("throws when no error matches RegExp", () => {
+    const response = createMockResponse({
+      errors: [{ message: "Something else" }],
+    });
+    assertThrows(
+      () => expectGraphqlResponse(response).error(/User \d+ not found/),
+      Error,
+      "Expected an error matching",
+    );
+  });
+
+  await t.step("throws when no errors", () => {
+    const response = createMockResponse({ data: { test: true }, errors: null });
+    assertThrows(
+      () => expectGraphqlResponse(response).error("error"),
+      Error,
+      "no errors present",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.noContent()", async (t) => {
+  await t.step("passes when data is null (alias for noData)", () => {
+    const response = createMockResponse({ data: null });
+    expectGraphqlResponse(response).noContent();
+  });
+
+  await t.step("throws when data is not null", () => {
+    const response = createMockResponse({ data: { test: true } });
+    assertThrows(
+      () => expectGraphqlResponse(response).noContent(),
+      Error,
+      "Expected no data, but data exists",
+    );
+  });
+});
+
+Deno.test("expectGraphqlResponse.hasContent()", async (t) => {
+  await t.step("passes when data is not null (alias for hasData)", () => {
+    const response = createMockResponse({ data: { test: true } });
+    expectGraphqlResponse(response).hasContent();
+  });
+
+  await t.step("throws when data is null", () => {
+    const response = createMockResponse({ data: null });
+    assertThrows(
+      () => expectGraphqlResponse(response).hasContent(),
+      Error,
+      "Expected data, but data is null",
+    );
+  });
+});

--- a/packages/probitas-client-graphql/integration_test.ts
+++ b/packages/probitas-client-graphql/integration_test.ts
@@ -49,7 +49,7 @@ Deno.test({
         .status(200)
         .hasData();
 
-      assertEquals(res.data?.__typename, "Query");
+      assertEquals(res.data()?.__typename, "Query");
     });
 
     await t.step("introspection query - __schema", async () => {
@@ -59,7 +59,7 @@ Deno.test({
 
       expectGraphqlResponse(res).ok().hasData();
 
-      assertEquals(res.data?.__schema.queryType.name, "Query");
+      assertEquals(res.data()?.__schema.queryType.name, "Query");
     });
 
     await t.step("query with variables", async () => {
@@ -76,7 +76,7 @@ Deno.test({
       );
 
       expectGraphqlResponse(res).ok();
-      assertEquals(res.data?.__type?.name, "Query");
+      assertEquals(res.data()?.__type?.name, "Query");
     });
 
     await t.step("query with operationName", async () => {

--- a/packages/probitas-client-graphql/response.ts
+++ b/packages/probitas-client-graphql/response.ts
@@ -17,21 +17,28 @@ export interface GraphqlResponseOptions<T> {
  */
 class GraphqlResponseImpl<T> implements GraphqlResponse<T> {
   readonly ok: boolean;
-  readonly data: T | null;
   readonly errors: readonly GraphqlErrorItem[] | null;
   readonly extensions?: Record<string, unknown>;
   readonly duration: number;
   readonly status: number;
+  readonly headers: Headers;
   readonly raw: globalThis.Response;
 
+  readonly #data: T | null;
+
   constructor(options: GraphqlResponseOptions<T>) {
-    this.data = options.data;
+    this.#data = options.data;
     this.errors = options.errors;
     this.ok = options.errors === null || options.errors.length === 0;
     this.extensions = options.extensions;
     this.duration = options.duration;
     this.status = options.status;
+    this.headers = options.raw.headers;
     this.raw = options.raw;
+  }
+
+  data<U = T>(): U | null {
+    return this.#data as U | null;
   }
 }
 

--- a/packages/probitas-client-graphql/types.ts
+++ b/packages/probitas-client-graphql/types.ts
@@ -26,9 +26,6 @@ export interface GraphqlResponse<T = any> {
   /** Whether the request was successful (no errors) */
   readonly ok: boolean;
 
-  /** Response data (null if errors occurred with no partial data) */
-  readonly data: T | null;
-
   /** GraphQL errors array (null if no errors) */
   readonly errors: readonly GraphqlErrorItem[] | null;
 
@@ -41,8 +38,17 @@ export interface GraphqlResponse<T = any> {
   /** HTTP status code */
   readonly status: number;
 
+  /** Headers from the HTTP response */
+  readonly headers: Headers;
+
   /** Raw Web standard Response (for streaming or special cases) */
   readonly raw: globalThis.Response;
+
+  /**
+   * Get response data (null if no data).
+   * Does not throw even if errors are present.
+   */
+  data<U = T>(): U | null;
 }
 
 /**
@@ -71,6 +77,9 @@ export interface GraphqlClientConfig extends CommonOptions {
 
   /** Default headers for all requests */
   readonly headers?: Record<string, string>;
+
+  /** WebSocket endpoint URL (for subscriptions) */
+  readonly wsEndpoint?: string;
 
   /** Custom fetch implementation (for testing/mocking) */
   readonly fetch?: typeof fetch;
@@ -106,6 +115,14 @@ export interface GraphqlClient extends AsyncDisposable {
     options?: GraphqlOptions,
   ): Promise<GraphqlResponse<TData>>;
 
+  /** Execute a GraphQL mutation (alias for mutation) */
+  // deno-lint-ignore no-explicit-any
+  mutate<TData = any, TVariables = Record<string, any>>(
+    mutation: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): Promise<GraphqlResponse<TData>>;
+
   /** Execute a GraphQL document (query or mutation) */
   // deno-lint-ignore no-explicit-any
   execute<TData = any, TVariables = Record<string, any>>(
@@ -113,6 +130,14 @@ export interface GraphqlClient extends AsyncDisposable {
     variables?: TVariables,
     options?: GraphqlOptions,
   ): Promise<GraphqlResponse<TData>>;
+
+  /** Subscribe to a GraphQL subscription via WebSocket */
+  // deno-lint-ignore no-explicit-any
+  subscribe<TData = any, TVariables = Record<string, any>>(
+    document: string,
+    variables?: TVariables,
+    options?: GraphqlOptions,
+  ): AsyncIterable<GraphqlResponse<TData>>;
 
   /** Close the client and release resources */
   close(): Promise<void>;


### PR DESCRIPTION
## Summary
- Add `mutate()` method as alias for `mutation()`
- Add `subscribe()` method for WebSocket-based GraphQL subscriptions
- Change `data` from property to `data<T>()` method
- Add expectation methods for spec compatibility: `noErrors()`, `error(string|RegExp)`, `noContent()`, `hasContent()`
- Add `wsEndpoint` to `GraphqlClientConfig`
- Add `headers` property to `GraphqlResponse`

## Test plan
- [x] All unit tests pass
- [x] Integration tests pass locally with docker compose