### PR TITLE
ci: Add GraphQL service for integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,10 @@ jobs:
         image: romk/grpc-helloworld-reflection
         ports:
           - 50051:50051
+      graphql:
+        image: npalm/graphql-java-demo
+        ports:
+          - 14000:8080
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2


### PR DESCRIPTION
## Summary
- Add GraphQL service (`npalm/graphql-java-demo`) to CI workflow for integration tests
- Update CLAUDE.md with CI integration test requirements and patterns

## Test plan
- [ ] CI workflow should now include GraphQL service
- [ ] Integration tests for `@probitas/client-graphql` should run in CI