### PR TITLE
docs: Add reference to specifications directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Client library collection for Probitas scenario testing framework.
 
+## Specifications
+
+Refer to `~/Desktop/probitas-client-specs/` for detailed specifications.
+
 ## Project Overview
 
 - **Runtime**: Deno 2.x


### PR DESCRIPTION
## Summary
- Add Specifications section to CLAUDE.md referencing `~/Desktop/probitas-client-specs/`
- Enables AI assistants to access detailed client specifications during development

## Test plan
- [x] Verify CLAUDE.md renders correctly