### PR TITLE
feat: Implement @probitas/client-sql-sqlite package

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -6,7 +6,8 @@
     "./packages/probitas-client-http",
     "./packages/probitas-client-sql",
     "./packages/probitas-client-sql-mysql",
-    "./packages/probitas-client-sql-postgres"
+    "./packages/probitas-client-sql-postgres",
+    "./packages/probitas-client-sql-sqlite"
   ],
   "exclude": [
     ".coverage/**",
@@ -30,6 +31,7 @@
     "jsr:@probitas/client-http@^0": "./packages/probitas-client-http/mod.ts",
     "jsr:@probitas/client-sql@^0": "./packages/probitas-client-sql/mod.ts",
     "jsr:@probitas/client-sql-mysql@^0": "./packages/probitas-client-sql-mysql/mod.ts",
-    "jsr:@probitas/client-sql-postgres@^0": "./packages/probitas-client-sql-postgres/mod.ts"
+    "jsr:@probitas/client-sql-postgres@^0": "./packages/probitas-client-sql-postgres/mod.ts",
+    "jsr:@probitas/client-sql-sqlite@^0": "./packages/probitas-client-sql-sqlite/mod.ts"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -2,14 +2,22 @@
   "version": "5",
   "specifiers": {
     "jsr:@cspotcode/outdent@0.8": "0.8.0",
+    "jsr:@db/sqlite@0.12": "0.12.0",
+    "jsr:@denosaurs/plug@1": "1.1.0",
+    "jsr:@std/assert@0.217": "0.217.0",
     "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/assert@^1.0.16": "1.0.16",
     "jsr:@std/async@^1.0.15": "1.0.15",
     "jsr:@std/data-structures@^1.0.9": "1.0.9",
+    "jsr:@std/encoding@1": "1.0.10",
+    "jsr:@std/fmt@1": "1.0.8",
+    "jsr:@std/fs@1": "1.0.20",
     "jsr:@std/fs@^1.0.19": "1.0.20",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/json@^1.0.2": "1.0.2",
     "jsr:@std/jsonc@^1.0.1": "1.0.2",
+    "jsr:@std/path@0.217": "0.217.0",
+    "jsr:@std/path@1": "1.1.3",
     "jsr:@std/path@^1.0.8": "1.1.3",
     "jsr:@std/path@^1.1.2": "1.1.3",
     "jsr:@std/path@^1.1.3": "1.1.3",
@@ -27,6 +35,25 @@
     "@cspotcode/outdent@0.8.0": {
       "integrity": "bbb3dea1443b4191a091644dfeaf3f182cca83e9003d211c50786c21792695f6"
     },
+    "@db/sqlite@0.12.0": {
+      "integrity": "dd1ef7f621ad50fc1e073a1c3609c4470bd51edc0994139c5bf9851de7a6d85f",
+      "dependencies": [
+        "jsr:@denosaurs/plug",
+        "jsr:@std/path@0.217"
+      ]
+    },
+    "@denosaurs/plug@1.1.0": {
+      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
+      "dependencies": [
+        "jsr:@std/encoding",
+        "jsr:@std/fmt",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
+      ]
+    },
+    "@std/assert@0.217.0": {
+      "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
+    },
     "@std/assert@1.0.16": {
       "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
       "dependencies": [
@@ -39,9 +66,16 @@
     "@std/data-structures@1.0.9": {
       "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
     },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
+    },
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
+    },
     "@std/fs@1.0.20": {
       "integrity": "e953206aae48d46ee65e8783ded459f23bec7dd1f3879512911c35e5484ea187",
       "dependencies": [
+        "jsr:@std/internal",
         "jsr:@std/path@^1.1.3"
       ]
     },
@@ -55,6 +89,12 @@
       "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
       "dependencies": [
         "jsr:@std/json"
+      ]
+    },
+    "@std/path@0.217.0": {
+      "integrity": "1217cc25534bca9a2f672d7fe7c6f356e4027df400c0e85c0ef3e4343bc67d11",
+      "dependencies": [
+        "jsr:@std/assert@0.217"
       ]
     },
     "@std/path@1.1.3": {
@@ -72,7 +112,7 @@
         "jsr:@std/assert@^1.0.15",
         "jsr:@std/async",
         "jsr:@std/data-structures",
-        "jsr:@std/fs",
+        "jsr:@std/fs@^1.0.19",
         "jsr:@std/internal",
         "jsr:@std/path@^1.1.2"
       ]
@@ -390,6 +430,13 @@
           "jsr:@probitas/client-sql@0",
           "jsr:@probitas/client@0",
           "npm:postgres@3"
+        ]
+      },
+      "packages/probitas-client-sql-sqlite": {
+        "dependencies": [
+          "jsr:@db/sqlite@0.12",
+          "jsr:@probitas/client-sql@0",
+          "jsr:@probitas/client@0"
         ]
       }
     }

--- a/packages/probitas-client-sql-sqlite/client.ts
+++ b/packages/probitas-client-sql-sqlite/client.ts
@@ -1,0 +1,312 @@
+import { type BindValue, Database } from "@db/sqlite";
+import {
+  SqlQueryResult,
+  type SqlTransaction,
+  type SqlTransactionOptions,
+} from "@probitas/client-sql";
+import type { SqliteClientConfig } from "./types.ts";
+import { convertSqliteError } from "./errors.ts";
+import {
+  SqliteTransactionImpl,
+  type SqliteTransactionOptions,
+} from "./transaction.ts";
+
+/** Internal type alias for bind parameters */
+type BindParams = BindValue[];
+
+/**
+ * SQLite client interface.
+ */
+export interface SqliteClient extends AsyncDisposable {
+  /** The client configuration. */
+  readonly config: SqliteClientConfig;
+
+  /** The SQL dialect identifier. */
+  readonly dialect: "sqlite";
+
+  /**
+   * Execute a SQL query.
+   * @param sql - SQL query string
+   * @param params - Optional query parameters
+   */
+  // deno-lint-ignore no-explicit-any
+  query<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>>;
+
+  /**
+   * Execute a query and return the first row or undefined.
+   * @param sql - SQL query string
+   * @param params - Optional query parameters
+   */
+  // deno-lint-ignore no-explicit-any
+  queryOne<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined>;
+
+  /**
+   * Execute a function within a transaction.
+   * Automatically commits on success or rolls back on error.
+   * @param fn - Function to execute within transaction
+   * @param options - Transaction options
+   */
+  transaction<T>(
+    fn: (tx: SqlTransaction) => Promise<T>,
+    options?: SqlTransactionOptions | SqliteTransactionOptions,
+  ): Promise<T>;
+
+  /**
+   * Backup the database to a file.
+   * Uses VACUUM INTO for a consistent backup.
+   * @param destPath - Destination file path for the backup
+   */
+  backup(destPath: string): Promise<void>;
+
+  /**
+   * Run VACUUM to rebuild the database file, reclaiming unused space.
+   */
+  vacuum(): Promise<void>;
+
+  /**
+   * Close the database connection.
+   */
+  close(): Promise<void>;
+}
+
+/**
+ * Create a SQLite client.
+ *
+ * @example
+ * ```typescript
+ * // Using file-based database
+ * const client = await createSqliteClient({
+ *   path: "./data.db",
+ * });
+ *
+ * // Using in-memory database
+ * const client = await createSqliteClient({
+ *   path: ":memory:",
+ * });
+ *
+ * // With WAL mode enabled
+ * const client = await createSqliteClient({
+ *   path: "./data.db",
+ *   wal: true,
+ * });
+ *
+ * // Read-only mode
+ * const client = await createSqliteClient({
+ *   path: "./data.db",
+ *   readonly: true,
+ * });
+ *
+ * const result = await client.query<{ id: number; name: string }>(
+ *   "SELECT * FROM users WHERE id = ?",
+ *   [1],
+ * );
+ *
+ * console.log(result.rows.first()); // { id: 1, name: "Alice" }
+ *
+ * await client.close();
+ * ```
+ */
+export function createSqliteClient(
+  config: SqliteClientConfig,
+): Promise<SqliteClient> {
+  try {
+    // Build open flags
+    // SQLITE_OPEN_READWRITE = 0x00000002
+    // SQLITE_OPEN_READONLY = 0x00000001
+    // SQLITE_OPEN_CREATE = 0x00000004
+    let flags: number;
+    if (config.readonly) {
+      flags = 0x00000001; // SQLITE_OPEN_READONLY
+    } else {
+      flags = 0x00000002 | 0x00000004; // SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+    }
+
+    const db = new Database(config.path, { flags });
+
+    // Apply pragmas (skip if readonly since PRAGMA writes aren't allowed)
+    if (!config.readonly) {
+      // Apply WAL mode if requested (default: true for better concurrency)
+      const walEnabled = config.wal ?? true;
+      if (walEnabled) {
+        db.exec("PRAGMA journal_mode = WAL");
+      }
+
+      // Apply sensible defaults for other pragmas
+      db.exec("PRAGMA foreign_keys = ON");
+      db.exec("PRAGMA busy_timeout = 5000");
+    }
+
+    return Promise.resolve(new SqliteClientImpl(config, db));
+  } catch (error) {
+    return Promise.reject(convertSqliteError(error));
+  }
+}
+
+class SqliteClientImpl implements SqliteClient {
+  readonly config: SqliteClientConfig;
+  readonly dialect = "sqlite" as const;
+  readonly #db: Database;
+  #closed = false;
+
+  constructor(config: SqliteClientConfig, db: Database) {
+    this.config = config;
+    this.#db = db;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  query<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>> {
+    if (this.#closed) {
+      return Promise.reject(
+        convertSqliteError(new Error("Client is closed")),
+      );
+    }
+
+    const startTime = performance.now();
+
+    try {
+      // Check if this is a SELECT query
+      const trimmedSql = sql.trim().toUpperCase();
+      const isSelect = trimmedSql.startsWith("SELECT") ||
+        trimmedSql.startsWith("PRAGMA") ||
+        trimmedSql.startsWith("EXPLAIN");
+
+      if (isSelect) {
+        // For SELECT queries, use query method
+        const stmt = this.#db.prepare(sql);
+        const rows = (
+          params
+            // deno-lint-ignore no-explicit-any
+            ? stmt.all<Record<string, any>>(...(params as BindParams))
+            // deno-lint-ignore no-explicit-any
+            : stmt.all<Record<string, any>>()
+        ) as T[];
+        stmt.finalize();
+        const duration = performance.now() - startTime;
+
+        return Promise.resolve(
+          new SqlQueryResult<T>({
+            ok: true,
+            rows: rows,
+            rowCount: rows.length,
+            duration,
+            metadata: {},
+          }),
+        );
+      } else {
+        // For INSERT/UPDATE/DELETE queries
+        const stmt = this.#db.prepare(sql);
+        if (params) {
+          stmt.run(...(params as BindParams));
+        } else {
+          stmt.run();
+        }
+        stmt.finalize();
+        const duration = performance.now() - startTime;
+
+        // Get affected rows and last insert id
+        const changes = this.#db.changes;
+        const lastInsertRowId = this.#db.lastInsertRowId;
+
+        return Promise.resolve(
+          new SqlQueryResult<T>({
+            ok: true,
+            rows: [],
+            rowCount: changes,
+            duration,
+            metadata: {
+              lastInsertId: lastInsertRowId > 0
+                ? BigInt(lastInsertRowId)
+                : undefined,
+            },
+          }),
+        );
+      }
+    } catch (error) {
+      return Promise.reject(convertSqliteError(error));
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async queryOne<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined> {
+    const result = await this.query<T>(sql, params);
+    return result.rows.first();
+  }
+
+  async transaction<T>(
+    fn: (tx: SqlTransaction) => Promise<T>,
+    options?: SqlTransactionOptions | SqliteTransactionOptions,
+  ): Promise<T> {
+    if (this.#closed) {
+      throw convertSqliteError(new Error("Client is closed"));
+    }
+
+    const tx = SqliteTransactionImpl.begin(
+      this.#db,
+      options as SqliteTransactionOptions,
+    );
+
+    try {
+      const result = await fn(tx);
+      await tx.commit();
+      return result;
+    } catch (error) {
+      await tx.rollback();
+      throw error;
+    }
+  }
+
+  backup(destPath: string): Promise<void> {
+    if (this.#closed) {
+      return Promise.reject(
+        convertSqliteError(new Error("Client is closed")),
+      );
+    }
+
+    try {
+      // SQLite backup using VACUUM INTO (available since SQLite 3.27.0)
+      // This creates a complete backup of the database to the specified file
+      this.#db.exec(`VACUUM INTO '${destPath.replace(/'/g, "''")}'`);
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(convertSqliteError(error));
+    }
+  }
+
+  vacuum(): Promise<void> {
+    if (this.#closed) {
+      return Promise.reject(
+        convertSqliteError(new Error("Client is closed")),
+      );
+    }
+
+    try {
+      this.#db.exec("VACUUM");
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(convertSqliteError(error));
+    }
+  }
+
+  close(): Promise<void> {
+    if (this.#closed) return Promise.resolve();
+    this.#closed = true;
+    this.#db.close();
+    return Promise.resolve();
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close();
+  }
+}

--- a/packages/probitas-client-sql-sqlite/deno.json
+++ b/packages/probitas-client-sql-sqlite/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@probitas/client-sql-sqlite",
+  "version": "0.0.0",
+  "exports": "./mod.ts",
+  "publish": {
+    "exclude": ["**/*_test.ts", "**/*_bench.ts"]
+  },
+  "imports": {
+    "@probitas/client": "jsr:@probitas/client@^0",
+    "@probitas/client-sql": "jsr:@probitas/client-sql@^0",
+    "@db/sqlite": "jsr:@db/sqlite@0.12"
+  }
+}

--- a/packages/probitas-client-sql-sqlite/errors.ts
+++ b/packages/probitas-client-sql-sqlite/errors.ts
@@ -1,0 +1,208 @@
+import {
+  ConstraintError,
+  DeadlockError,
+  QuerySyntaxError,
+  SqlError,
+  type SqlErrorOptions,
+} from "@probitas/client-sql";
+
+/**
+ * SQLite-specific error kinds.
+ */
+export type SqliteErrorKind = "database_locked" | "readonly" | "busy";
+
+/**
+ * Options for SqliteError constructor.
+ */
+export interface SqliteErrorOptions extends SqlErrorOptions {
+  /** SQLite extended error code. */
+  readonly extendedCode?: number;
+}
+
+/**
+ * Base error class for SQLite-specific errors.
+ * Extends SqlError with SQLite-specific properties like extendedCode.
+ */
+export class SqliteError extends SqlError {
+  override readonly name: string = "SqliteError";
+  readonly extendedCode?: number;
+
+  constructor(
+    message: string,
+    options?: SqliteErrorOptions,
+  ) {
+    super(message, "unknown", options);
+    this.extendedCode = options?.extendedCode;
+  }
+}
+
+/**
+ * Error thrown when the database is locked.
+ */
+export class DatabaseLockedError extends SqliteError {
+  override readonly name = "DatabaseLockedError";
+  readonly sqliteKind = "database_locked" as const;
+
+  constructor(message: string, options?: SqliteErrorOptions) {
+    super(message, options);
+  }
+}
+
+/**
+ * Error thrown when trying to write to a readonly database.
+ */
+export class ReadonlyDatabaseError extends SqliteError {
+  override readonly name = "ReadonlyDatabaseError";
+  readonly sqliteKind = "readonly" as const;
+
+  constructor(message: string, options?: SqliteErrorOptions) {
+    super(message, options);
+  }
+}
+
+/**
+ * Error thrown when the database is busy.
+ */
+export class BusyError extends SqliteError {
+  override readonly name = "BusyError";
+  readonly sqliteKind = "busy" as const;
+
+  constructor(message: string, options?: SqliteErrorOptions) {
+    super(message, options);
+  }
+}
+
+// SQLite Result Codes (primary codes)
+// See: https://www.sqlite.org/rescode.html
+const SQLITE_ERROR = 1;
+const SQLITE_BUSY = 5;
+const SQLITE_LOCKED = 6;
+const SQLITE_READONLY = 8;
+const SQLITE_CONSTRAINT = 19;
+
+/**
+ * Convert a @db/sqlite error to the appropriate error class.
+ *
+ * Note: @db/sqlite throws plain Error objects without SQLite error codes.
+ * Error classification is based on message content analysis.
+ */
+export function convertSqliteError(error: unknown): SqlError {
+  if (!(error instanceof Error)) {
+    return new SqliteError(String(error));
+  }
+
+  // @db/sqlite errors may have code property (but often don't)
+  const err = error as Error & {
+    code?: number;
+  };
+
+  const options: SqliteErrorOptions = {
+    cause: error,
+    extendedCode: err.code,
+  };
+
+  const message = err.message.toLowerCase();
+
+  // Check for busy/locked errors first (can be retried)
+  if (message.includes("database is busy") || message.includes("sqlite_busy")) {
+    return new BusyError(err.message, options);
+  }
+
+  if (
+    message.includes("database is locked") ||
+    message.includes("database table is locked") ||
+    message.includes("sqlite_locked")
+  ) {
+    // SQLITE_LOCKED can be a deadlock in some cases
+    return new DeadlockError(err.message, options);
+  }
+
+  if (
+    message.includes("readonly database") ||
+    message.includes("attempt to write a readonly database") ||
+    message.includes("sqlite_readonly")
+  ) {
+    return new ReadonlyDatabaseError(err.message, options);
+  }
+
+  // Check for constraint violations (most specific patterns first)
+  if (message.includes("constraint failed") || message.includes("constraint")) {
+    let constraint = "unknown";
+
+    // Try to extract constraint name from message
+    // Pattern: "UNIQUE constraint failed: table.column"
+    const uniqueMatch = err.message.match(/UNIQUE constraint failed: (\S+)/i);
+    if (uniqueMatch) {
+      constraint = uniqueMatch[1];
+      return new ConstraintError(err.message, constraint, options);
+    }
+
+    // Pattern: "PRIMARY KEY constraint failed"
+    if (message.includes("primary key constraint")) {
+      constraint = "PRIMARY KEY";
+      return new ConstraintError(err.message, constraint, options);
+    }
+
+    // Pattern: "FOREIGN KEY constraint failed"
+    if (message.includes("foreign key constraint")) {
+      constraint = "FOREIGN KEY";
+      return new ConstraintError(err.message, constraint, options);
+    }
+
+    // Pattern: "CHECK constraint failed: constraint_name"
+    const checkMatch = err.message.match(/CHECK constraint failed: (\S+)/i);
+    if (checkMatch) {
+      constraint = checkMatch[1];
+      return new ConstraintError(err.message, constraint, options);
+    }
+
+    // Pattern: "NOT NULL constraint failed: table.column"
+    const notNullMatch = err.message.match(
+      /NOT NULL constraint failed: (\S+)/i,
+    );
+    if (notNullMatch) {
+      constraint = notNullMatch[1];
+      return new ConstraintError(err.message, constraint, options);
+    }
+
+    // Generic constraint error
+    return new ConstraintError(err.message, constraint, options);
+  }
+
+  // Check for syntax errors based on message content
+  // SQLite reports these as general errors with descriptive messages
+  if (
+    message.includes("syntax error") ||
+    message.includes("no such column") ||
+    message.includes("no such table") ||
+    message.includes("no such function") ||
+    message.includes('near "') ||
+    message.includes("incomplete input") ||
+    message.includes("unrecognized token")
+  ) {
+    return new QuerySyntaxError(err.message, options);
+  }
+
+  // If we have an error code, try to classify by code
+  if (err.code !== undefined) {
+    const primaryCode = err.code & 0xff;
+
+    if (primaryCode === SQLITE_BUSY) {
+      return new BusyError(err.message, options);
+    }
+    if (primaryCode === SQLITE_LOCKED) {
+      return new DeadlockError(err.message, options);
+    }
+    if (primaryCode === SQLITE_READONLY) {
+      return new ReadonlyDatabaseError(err.message, options);
+    }
+    if (primaryCode === SQLITE_CONSTRAINT) {
+      return new ConstraintError(err.message, "unknown", options);
+    }
+    if (primaryCode === SQLITE_ERROR) {
+      return new QuerySyntaxError(err.message, options);
+    }
+  }
+
+  return new SqliteError(err.message, options);
+}

--- a/packages/probitas-client-sql-sqlite/errors_test.ts
+++ b/packages/probitas-client-sql-sqlite/errors_test.ts
@@ -1,0 +1,171 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { SqlError } from "@probitas/client-sql";
+import {
+  BusyError,
+  convertSqliteError,
+  DatabaseLockedError,
+  ReadonlyDatabaseError,
+  SqliteError,
+} from "./errors.ts";
+
+Deno.test("SqliteError", async (t) => {
+  await t.step("extends SqlError", () => {
+    const error = new SqliteError("test error");
+    assertInstanceOf(error, SqlError);
+    assertInstanceOf(error, Error);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new SqliteError("test error", {
+      extendedCode: 2067,
+    });
+
+    assertEquals(error.name, "SqliteError");
+    assertEquals(error.message, "test error");
+    assertEquals(error.kind, "unknown");
+    assertEquals(error.extendedCode, 2067);
+  });
+
+  await t.step("supports error chaining", () => {
+    const cause = new Error("original error");
+    const error = new SqliteError("wrapped", { cause });
+
+    assertEquals(error.cause, cause);
+  });
+});
+
+Deno.test("DatabaseLockedError", async (t) => {
+  await t.step("extends SqliteError with database_locked sqliteKind", () => {
+    const error = new DatabaseLockedError("database is locked", {
+      extendedCode: 6,
+    });
+
+    assertInstanceOf(error, SqliteError);
+    assertEquals(error.name, "DatabaseLockedError");
+    assertEquals(error.sqliteKind, "database_locked");
+    assertEquals(error.extendedCode, 6);
+  });
+});
+
+Deno.test("ReadonlyDatabaseError", async (t) => {
+  await t.step("extends SqliteError with readonly sqliteKind", () => {
+    const error = new ReadonlyDatabaseError(
+      "attempt to write a readonly database",
+    );
+
+    assertInstanceOf(error, SqliteError);
+    assertEquals(error.name, "ReadonlyDatabaseError");
+    assertEquals(error.sqliteKind, "readonly");
+  });
+});
+
+Deno.test("BusyError", async (t) => {
+  await t.step("extends SqliteError with busy sqliteKind", () => {
+    const error = new BusyError("database is busy");
+
+    assertInstanceOf(error, SqliteError);
+    assertEquals(error.name, "BusyError");
+    assertEquals(error.sqliteKind, "busy");
+  });
+});
+
+Deno.test("convertSqliteError", async (t) => {
+  await t.step("handles non-Error values", () => {
+    const error = convertSqliteError("string error");
+
+    assertInstanceOf(error, SqliteError);
+    assertEquals(error.message, "string error");
+    assertEquals(error.kind, "unknown");
+  });
+
+  await t.step("converts 'database is busy' message to BusyError", () => {
+    const sqliteError = new Error("database is busy");
+
+    const error = convertSqliteError(sqliteError);
+
+    assertInstanceOf(error, BusyError);
+    assertEquals((error as BusyError).sqliteKind, "busy");
+  });
+
+  await t.step("converts 'database is locked' message to DeadlockError", () => {
+    const sqliteError = new Error("database table is locked");
+
+    const error = convertSqliteError(sqliteError);
+
+    assertEquals(error.kind, "deadlock");
+  });
+
+  await t.step(
+    "converts readonly database message to ReadonlyDatabaseError",
+    () => {
+      const sqliteError = new Error("attempt to write a readonly database");
+
+      const error = convertSqliteError(sqliteError);
+
+      assertInstanceOf(error, ReadonlyDatabaseError);
+      assertEquals((error as ReadonlyDatabaseError).sqliteKind, "readonly");
+    },
+  );
+
+  await t.step(
+    "converts UNIQUE constraint failed message to ConstraintError",
+    () => {
+      const sqliteError = new Error("UNIQUE constraint failed: users.email");
+
+      const error = convertSqliteError(sqliteError);
+
+      assertEquals(error.kind, "constraint");
+    },
+  );
+
+  await t.step(
+    "converts constraint message with code to ConstraintError",
+    () => {
+      const sqliteError = Object.assign(
+        new Error("UNIQUE constraint failed"),
+        {
+          code: 2067,
+        },
+      );
+
+      const error = convertSqliteError(sqliteError);
+
+      assertEquals(error.kind, "constraint");
+    },
+  );
+
+  await t.step("converts syntax error message to QuerySyntaxError", () => {
+    const sqliteError = new Error('near "SELEC": syntax error');
+
+    const error = convertSqliteError(sqliteError);
+
+    assertEquals(error.kind, "query");
+  });
+
+  await t.step("converts 'no such table' to QuerySyntaxError", () => {
+    const sqliteError = new Error("no such table: users");
+
+    const error = convertSqliteError(sqliteError);
+
+    assertEquals(error.kind, "query");
+  });
+
+  await t.step("preserves cause in converted error", () => {
+    const originalError = new Error("UNIQUE constraint failed: test.code");
+
+    const error = convertSqliteError(originalError);
+
+    assertEquals(error.cause, originalError);
+  });
+
+  await t.step("handles errors with code property", () => {
+    const sqliteError = Object.assign(new Error("some sqlite error"), {
+      code: 5,
+    });
+
+    const error = convertSqliteError(sqliteError);
+
+    assertInstanceOf(error, BusyError);
+    assertEquals(error.extendedCode, 5);
+  });
+});

--- a/packages/probitas-client-sql-sqlite/integration_test.ts
+++ b/packages/probitas-client-sql-sqlite/integration_test.ts
@@ -1,0 +1,406 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import {
+  ConstraintError,
+  createSqliteClient,
+  expectSqlQueryResult,
+  QuerySyntaxError,
+  type SqliteClient,
+} from "./mod.ts";
+
+Deno.test({
+  name: "Integration: SqliteClient",
+  async fn(t) {
+    await t.step("has dialect property", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        assertEquals(client.dialect, "sqlite");
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("executes simple SELECT query", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        const result = await client.query<{ value: number }>(
+          "SELECT 1 as value",
+        );
+
+        assertEquals(result.ok, true);
+        assertEquals(result.rows.first(), { value: 1 });
+        assertEquals(result.rowCount, 1);
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("executes query with parameters", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        const result = await client.query<{ a: number; b: string }>(
+          "SELECT ? as a, ? as b",
+          [42, "hello"],
+        );
+
+        assertEquals(result.rows.first(), { a: 42, b: "hello" });
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("creates table and inserts data", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        await client.query(`
+          CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT UNIQUE
+          )
+        `);
+
+        const insertResult = await client.query(
+          "INSERT INTO users (name, email) VALUES (?, ?)",
+          ["Alice", "alice@example.com"],
+        );
+
+        assertEquals(insertResult.ok, true);
+        assertEquals(insertResult.rowCount, 1);
+        assertEquals(insertResult.metadata.lastInsertId, 1n);
+
+        const selectResult = await client.query<
+          { id: number; name: string; email: string }
+        >(
+          "SELECT * FROM users WHERE id = ?",
+          [1],
+        );
+
+        assertEquals(selectResult.rows.first(), {
+          id: 1,
+          name: "Alice",
+          email: "alice@example.com",
+        });
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("queryOne returns first row or undefined", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        await client.query(
+          "CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT)",
+        );
+
+        const empty = await client.queryOne<{ id: number; value: string }>(
+          "SELECT * FROM items WHERE id = ?",
+          [999],
+        );
+        assertEquals(empty, undefined);
+
+        await client.query(
+          "INSERT INTO items (id, value) VALUES (?, ?)",
+          [1, "test"],
+        );
+
+        const found = await client.queryOne<{ id: number; value: string }>(
+          "SELECT * FROM items WHERE id = ?",
+          [1],
+        );
+        assertEquals(found, { id: 1, value: "test" });
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("handles syntax errors", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        await assertRejects(
+          () => client.query("SELEC * FROM users"),
+          QuerySyntaxError,
+        );
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("handles constraint violations", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        await client.query(`
+          CREATE TABLE unique_test (
+            id INTEGER PRIMARY KEY,
+            code TEXT UNIQUE
+          )
+        `);
+
+        await client.query(
+          "INSERT INTO unique_test (code) VALUES (?)",
+          ["ABC"],
+        );
+
+        await assertRejects(
+          () =>
+            client.query(
+              "INSERT INTO unique_test (code) VALUES (?)",
+              ["ABC"],
+            ),
+          ConstraintError,
+        );
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("transaction commits on success", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        await client.query(
+          "CREATE TABLE tx_test (id INTEGER PRIMARY KEY, value TEXT)",
+        );
+
+        await client.transaction(async (tx) => {
+          await tx.query("INSERT INTO tx_test (value) VALUES (?)", ["one"]);
+          await tx.query("INSERT INTO tx_test (value) VALUES (?)", ["two"]);
+        });
+
+        const result = await client.query<{ id: number; value: string }>(
+          "SELECT * FROM tx_test ORDER BY id",
+        );
+
+        assertEquals(result.rows.length, 2);
+        assertEquals(result.rows[0].value, "one");
+        assertEquals(result.rows[1].value, "two");
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("transaction rolls back on error", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        await client.query(
+          "CREATE TABLE rollback_test (id INTEGER PRIMARY KEY, value TEXT)",
+        );
+
+        try {
+          await client.transaction(async (tx) => {
+            await tx.query(
+              "INSERT INTO rollback_test (value) VALUES (?)",
+              ["should rollback"],
+            );
+            throw new Error("Intentional error");
+          });
+        } catch {
+          // Expected
+        }
+
+        const result = await client.query<{ id: number; value: string }>(
+          "SELECT * FROM rollback_test",
+        );
+
+        assertEquals(result.rows.length, 0);
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("transaction with isolation level", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        await client.query(
+          "CREATE TABLE isolation_test (id INTEGER PRIMARY KEY, value TEXT)",
+        );
+
+        await client.transaction(
+          async (tx) => {
+            await tx.query(
+              "INSERT INTO isolation_test (value) VALUES (?)",
+              ["serializable"],
+            );
+          },
+          { isolationLevel: "serializable" },
+        );
+
+        const result = await client.query<{ value: string }>(
+          "SELECT value FROM isolation_test",
+        );
+
+        assertEquals(result.rows.first()?.value, "serializable");
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("supports AsyncDisposable", async () => {
+      let clientRef: SqliteClient | undefined;
+
+      {
+        await using client = await createSqliteClient({
+          path: ":memory:",
+        });
+        clientRef = client;
+
+        const result = await client.query("SELECT 1 as value");
+        assertEquals(result.ok, true);
+      }
+
+      // After the block, client should be closed
+      // Attempting to use it should throw
+      if (clientRef) {
+        await assertRejects(
+          () => clientRef!.query("SELECT 1"),
+          Error,
+          "Client is closed",
+        );
+      }
+    });
+
+    await t.step("expectSqlQueryResult works with SQLite results", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        await client.query(`
+          CREATE TABLE expect_test (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT
+          )
+        `);
+
+        await client.query(
+          "INSERT INTO expect_test (name) VALUES (?)",
+          ["Alice"],
+        );
+        await client.query(
+          "INSERT INTO expect_test (name) VALUES (?)",
+          ["Bob"],
+        );
+
+        const result = await client.query<{ id: number; name: string }>(
+          "SELECT * FROM expect_test ORDER BY id",
+        );
+
+        expectSqlQueryResult(result)
+          .ok()
+          .hasContent()
+          .rows(2)
+          .rowContains({ name: "Alice" });
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("applies WAL mode when wal: true", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+        wal: true,
+      });
+
+      try {
+        const journalResult = await client.query<{ journal_mode: string }>(
+          "PRAGMA journal_mode",
+        );
+        assertEquals(journalResult.rows.first()?.journal_mode, "memory");
+        // Note: In-memory databases return "memory" even with WAL enabled
+        // WAL is effectively ignored for :memory: databases
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("vacuum() reclaims space", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      try {
+        await client.query("CREATE TABLE vacuum_test (id INTEGER, data TEXT)");
+        await client.query(
+          "INSERT INTO vacuum_test VALUES (1, ?)",
+          ["x".repeat(1000)],
+        );
+        await client.query("DELETE FROM vacuum_test WHERE id = 1");
+
+        // VACUUM should succeed without error
+        await client.vacuum();
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("backup() creates database backup", async () => {
+      const client = await createSqliteClient({
+        path: ":memory:",
+      });
+
+      const backupPath = await Deno.makeTempFile({ suffix: ".db" });
+
+      try {
+        await client.query("CREATE TABLE backup_test (id INTEGER, name TEXT)");
+        await client.query(
+          "INSERT INTO backup_test VALUES (1, ?)",
+          ["Alice"],
+        );
+
+        // Create backup
+        await client.backup(backupPath);
+
+        // Verify backup by opening it
+        const backupClient = await createSqliteClient({
+          path: backupPath,
+          readonly: true,
+        });
+
+        try {
+          const result = await backupClient.query<{ id: number; name: string }>(
+            "SELECT * FROM backup_test",
+          );
+          assertEquals(result.rows.first(), { id: 1, name: "Alice" });
+        } finally {
+          await backupClient.close();
+        }
+      } finally {
+        await client.close();
+        // Clean up backup file
+        try {
+          await Deno.remove(backupPath);
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    });
+  },
+});

--- a/packages/probitas-client-sql-sqlite/mod.ts
+++ b/packages/probitas-client-sql-sqlite/mod.ts
@@ -1,0 +1,14 @@
+// Client
+export * from "./client.ts";
+
+// Transaction
+export type * from "./transaction.ts";
+
+// Types
+export type * from "./types.ts";
+
+// Errors
+export * from "./errors.ts";
+
+// Re-export common types from @probitas/client-sql
+export * from "@probitas/client-sql";

--- a/packages/probitas-client-sql-sqlite/transaction.ts
+++ b/packages/probitas-client-sql-sqlite/transaction.ts
@@ -1,0 +1,203 @@
+import type { BindValue, Database } from "@db/sqlite";
+import {
+  type SqlIsolationLevel,
+  SqlQueryResult,
+  type SqlTransaction,
+  type SqlTransactionOptions,
+} from "@probitas/client-sql";
+import { convertSqliteError } from "./errors.ts";
+
+/** Internal type alias for bind parameters */
+type BindParams = BindValue[];
+
+/**
+ * SQLite transaction behavior mode.
+ *
+ * - "deferred": Locks are acquired on first read/write (default)
+ * - "immediate": Acquires RESERVED lock immediately
+ * - "exclusive": Acquires EXCLUSIVE lock immediately
+ */
+export type SqliteTransactionMode = "deferred" | "immediate" | "exclusive";
+
+/**
+ * SQLite-specific transaction options.
+ */
+export interface SqliteTransactionOptions extends SqlTransactionOptions {
+  /**
+   * Transaction behavior mode.
+   * @default "deferred"
+   */
+  readonly mode?: SqliteTransactionMode;
+}
+
+/**
+ * Map isolation levels to SQLite transaction modes.
+ * SQLite has limited isolation level support:
+ * - read_uncommitted requires PRAGMA read_uncommitted = 1 (not recommended)
+ * - read_committed, repeatable_read, serializable are all effectively serializable in SQLite
+ */
+function mapIsolationLevelToMode(
+  level: SqlIsolationLevel,
+): SqliteTransactionMode {
+  switch (level) {
+    case "read_uncommitted":
+    case "read_committed":
+      return "deferred";
+    case "repeatable_read":
+      return "immediate";
+    case "serializable":
+      return "exclusive";
+    default:
+      return "deferred";
+  }
+}
+
+export class SqliteTransactionImpl implements SqlTransaction {
+  readonly #db: Database;
+  #finished = false;
+
+  private constructor(db: Database) {
+    this.#db = db;
+  }
+
+  /**
+   * Begin a new transaction.
+   */
+  static begin(
+    db: Database,
+    options?: SqliteTransactionOptions,
+  ): SqliteTransactionImpl {
+    try {
+      // Determine transaction mode
+      let mode: SqliteTransactionMode = options?.mode ?? "deferred";
+      if (!options?.mode && options?.isolationLevel) {
+        mode = mapIsolationLevelToMode(options.isolationLevel);
+      }
+
+      // Begin transaction with appropriate mode
+      const modeStr = mode.toUpperCase();
+      db.exec(`BEGIN ${modeStr} TRANSACTION`);
+
+      return new SqliteTransactionImpl(db);
+    } catch (error) {
+      throw convertSqliteError(error);
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  query<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>> {
+    if (this.#finished) {
+      return Promise.reject(
+        convertSqliteError(new Error("Transaction is already finished")),
+      );
+    }
+
+    const startTime = performance.now();
+
+    try {
+      // Check if this is a SELECT query
+      const trimmedSql = sql.trim().toUpperCase();
+      const isSelect = trimmedSql.startsWith("SELECT") ||
+        trimmedSql.startsWith("PRAGMA") ||
+        trimmedSql.startsWith("EXPLAIN");
+
+      if (isSelect) {
+        // For SELECT queries, use query method
+        const stmt = this.#db.prepare(sql);
+        const rows = (
+          params
+            // deno-lint-ignore no-explicit-any
+            ? stmt.all<Record<string, any>>(...(params as BindParams))
+            // deno-lint-ignore no-explicit-any
+            : stmt.all<Record<string, any>>()
+        ) as T[];
+        stmt.finalize();
+        const duration = performance.now() - startTime;
+
+        return Promise.resolve(
+          new SqlQueryResult<T>({
+            ok: true,
+            rows: rows,
+            rowCount: rows.length,
+            duration,
+            metadata: {},
+          }),
+        );
+      } else {
+        // For INSERT/UPDATE/DELETE queries
+        const stmt = this.#db.prepare(sql);
+        if (params) {
+          stmt.run(...(params as BindParams));
+        } else {
+          stmt.run();
+        }
+        stmt.finalize();
+        const duration = performance.now() - startTime;
+
+        // Get affected rows and last insert id
+        const changes = this.#db.changes;
+        const lastInsertRowId = this.#db.lastInsertRowId;
+
+        return Promise.resolve(
+          new SqlQueryResult<T>({
+            ok: true,
+            rows: [],
+            rowCount: changes,
+            duration,
+            metadata: {
+              lastInsertId: lastInsertRowId > 0
+                ? BigInt(lastInsertRowId)
+                : undefined,
+            },
+          }),
+        );
+      }
+    } catch (error) {
+      return Promise.reject(convertSqliteError(error));
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async queryOne<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined> {
+    const result = await this.query<T>(sql, params);
+    return result.rows.first();
+  }
+
+  commit(): Promise<void> {
+    if (this.#finished) {
+      return Promise.reject(
+        convertSqliteError(new Error("Transaction is already finished")),
+      );
+    }
+
+    try {
+      this.#db.exec("COMMIT");
+      this.#finished = true;
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(convertSqliteError(error));
+    }
+  }
+
+  rollback(): Promise<void> {
+    if (this.#finished) {
+      return Promise.reject(
+        convertSqliteError(new Error("Transaction is already finished")),
+      );
+    }
+
+    try {
+      this.#db.exec("ROLLBACK");
+      this.#finished = true;
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(convertSqliteError(error));
+    }
+  }
+}

--- a/packages/probitas-client-sql-sqlite/types.ts
+++ b/packages/probitas-client-sql-sqlite/types.ts
@@ -1,0 +1,25 @@
+import type { CommonOptions } from "@probitas/client";
+
+/**
+ * Configuration for creating a SQLite client.
+ */
+export interface SqliteClientConfig extends CommonOptions {
+  /**
+   * Database file path.
+   * Use ":memory:" for an in-memory database.
+   */
+  readonly path: string;
+
+  /**
+   * Open the database in read-only mode.
+   * @default false
+   */
+  readonly readonly?: boolean;
+
+  /**
+   * Enable WAL (Write-Ahead Logging) mode.
+   * WAL mode provides better concurrency and performance.
+   * @default true
+   */
+  readonly wal?: boolean;
+}


### PR DESCRIPTION
## Summary

- Add `@probitas/client-sql-sqlite` package for SQLite database testing
- Implement `SqliteClient` interface with `query`, `queryOne`, `transaction`, `backup`, `vacuum` methods
- Support WAL mode (default enabled) and readonly mode
- SQLite-specific error mapping (`BusyError`, `DatabaseLockedError`, `ReadonlyDatabaseError`)
- Transaction support with DEFERRED/IMMEDIATE/EXCLUSIVE modes

## Test plan

- [x] Unit tests for error mapping (`errors_test.ts`)
- [x] Integration tests for all client methods (`integration_test.ts`)
- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] `deno task check` passes
- [x] `deno task test` passes (108 tests)