### PR TITLE
ci: Add Redis service for integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,15 @@ jobs:
         env:
           DENO_KV_SQLITE_PATH: ":memory:"
           DENO_KV_ACCESS_TOKEN: testtoken1234
+      redis:
+        image: redis:7
+        ports:
+          - 16379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     env:
       DENO_KV_ACCESS_TOKEN: testtoken1234
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ When adding a new integration test:
 | client-http    | echo-http    | `ghcr.io/jsr-probitas/echo-http`    | 18080      | 18080   |
 | client-grpc    | echo-grpc    | `ghcr.io/jsr-probitas/echo-grpc`    | 50051      | 50051   |
 | client-graphql | echo-graphql | `ghcr.io/jsr-probitas/echo-graphql` | 14000      | 14000   |
+| client-redis   | redis        | `redis:7`                           | 16379      | 16379   |
 
 Example `compose.yaml` structure:
 


### PR DESCRIPTION
## Summary
- Add Redis service to GitHub Actions workflow to enable `client-redis` integration tests in CI
- Update CLAUDE.md documentation to include Redis in the Integration Test Services table

## Test plan
- [ ] Verify CI workflow runs successfully with Redis service
- [ ] Confirm Redis integration tests execute in CI (previously skipped due to missing service)