### PR TITLE
feat: Implement @probitas/client-sql-duckdb package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,16 @@ jobs:
         with:
           mongodb-version: "7.0"
           mongodb-replica-set: rs0
+
+      - name: Install libduckdb
+        run: |
+          DUCKDB_VERSION="1.4.2"
+          wget -q "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip"
+          unzip -q libduckdb-linux-amd64.zip -d libduckdb
+          sudo mv libduckdb/duckdb.h /usr/local/include/
+          sudo mv libduckdb/libduckdb.so /usr/local/lib/
+          sudo ldconfig
+
       - run: |
           deno task test:coverage
         timeout-minutes: 5

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -9,6 +9,7 @@
     "./packages/probitas-client-rabbitmq",
     "./packages/probitas-client-redis",
     "./packages/probitas-client-sql",
+    "./packages/probitas-client-sql-duckdb",
     "./packages/probitas-client-sql-mysql",
     "./packages/probitas-client-sql-postgres",
     "./packages/probitas-client-sql-sqlite"
@@ -39,6 +40,7 @@
     "jsr:@probitas/client-rabbitmq@^0": "./packages/probitas-client-rabbitmq/mod.ts",
     "jsr:@probitas/client-redis@^0": "./packages/probitas-client-redis/mod.ts",
     "jsr:@probitas/client-sql@^0": "./packages/probitas-client-sql/mod.ts",
+    "jsr:@probitas/client-sql-duckdb@^0": "./packages/probitas-client-sql-duckdb/mod.ts",
     "jsr:@probitas/client-sql-mysql@^0": "./packages/probitas-client-sql-mysql/mod.ts",
     "jsr:@probitas/client-sql-postgres@^0": "./packages/probitas-client-sql-postgres/mod.ts",
     "jsr:@probitas/client-sql-sqlite@^0": "./packages/probitas-client-sql-sqlite/mod.ts"

--- a/deno.lock
+++ b/deno.lock
@@ -5,18 +5,25 @@
     "jsr:@db/sqlite@0.12": "0.12.0",
     "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@std/assert@0.217": "0.217.0",
+    "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/assert@^1.0.16": "1.0.16",
+    "jsr:@std/async@^1.0.15": "1.0.15",
+    "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fs@1": "1.0.20",
+    "jsr:@std/fs@^1.0.19": "1.0.20",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/json@^1.0.2": "1.0.2",
     "jsr:@std/jsonc@^1.0.1": "1.0.2",
     "jsr:@std/path@0.217": "0.217.0",
     "jsr:@std/path@1": "1.1.3",
     "jsr:@std/path@^1.0.8": "1.1.3",
+    "jsr:@std/path@^1.1.2": "1.1.3",
     "jsr:@std/path@^1.1.3": "1.1.3",
     "jsr:@std/semver@^1.0.4": "1.0.7",
+    "jsr:@std/testing@^1.0.16": "1.0.16",
+    "npm:@duckdb/node-api@1.4.2-r.1": "1.4.2-r.1",
     "npm:@grpc/grpc-js@1.12": "1.12.6",
     "npm:@grpc/proto-loader@0.7": "0.7.15",
     "npm:@types/node@*": "24.2.0",
@@ -24,6 +31,7 @@
     "npm:grpc-reflection-js@0.3": "0.3.0_@grpc+grpc-js@1.12.6",
     "npm:ioredis@^5.4.1": "5.8.2",
     "npm:mongodb@^6.12.0": "6.21.0",
+    "npm:mysql2@*": "3.15.3",
     "npm:mysql2@^3.11.0": "3.15.3",
     "npm:postgres@3": "3.4.7"
   },
@@ -43,7 +51,7 @@
       "dependencies": [
         "jsr:@std/encoding",
         "jsr:@std/fmt",
-        "jsr:@std/fs",
+        "jsr:@std/fs@1",
         "jsr:@std/path@1"
       ]
     },
@@ -55,6 +63,12 @@
       "dependencies": [
         "jsr:@std/internal"
       ]
+    },
+    "@std/async@1.0.15": {
+      "integrity": "55d1d9d04f99403fe5730ab16bdcc3c47f658a6bf054cafb38a50f046238116e"
+    },
+    "@std/data-structures@1.0.9": {
+      "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
     },
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
@@ -95,9 +109,61 @@
     },
     "@std/semver@1.0.7": {
       "integrity": "7d5f65391762dc4358abde80fc3354086ddb40101f140295e60f290c138887d0"
+    },
+    "@std/testing@1.0.16": {
+      "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.15",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs@^1.0.19",
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.2"
+      ]
     }
   },
   "npm": {
+    "@duckdb/node-api@1.4.2-r.1": {
+      "integrity": "sha512-8Ef4R/Lq+rXTpcqZIJZe6ALfgMGxy88HmiPvRpWrRw1fUTy85x1U0NnGrqCklZsmWyZUdPwVYj90MQOF2MY/TA==",
+      "dependencies": [
+        "@duckdb/node-bindings"
+      ]
+    },
+    "@duckdb/node-bindings-darwin-arm64@1.4.2-r.1": {
+      "integrity": "sha512-C4yBI3zBX7iZ9iq8zJDvPatXA+2xM22sg1kX3fx76nG+qTqKtU/dGFVYL7Fx6cBYxBO1ZZ8Y+vjgYb6/bich8A==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@duckdb/node-bindings-darwin-x64@1.4.2-r.1": {
+      "integrity": "sha512-dgTSBuEfWyhymYovsGoRESjqcJuZWwJqla9l89SSsBDrGYcUp+EHsXUF73oUCspzTesT2lOvHrDufO8pKgtudw==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@duckdb/node-bindings-linux-arm64@1.4.2-r.1": {
+      "integrity": "sha512-r2Ml1LvU2vkVMx4YU04T79FjGkYg8YMVtbOz7j740SZGIi5Cch5P1/oy48jJBWRqoaXuqimpYWeTZiGVeCQiZA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@duckdb/node-bindings-linux-x64@1.4.2-r.1": {
+      "integrity": "sha512-ed5KiNIu1rqSva5rgo4PRVYSmBolAMVqGFWsYWLoRZ94ka2F/dHwJNkarCTmBFCEDGVZWzWzjRyWTQgYTvQxTg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@duckdb/node-bindings-win32-x64@1.4.2-r.1": {
+      "integrity": "sha512-kIIT8tuoW3mzr9EPcdSoKfv9CgOhTqRryHDI10Z0nuhc9UhqOWPUM/LnSUebfo1mdD9Drm7YrKCKYxNTr5dqBQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@duckdb/node-bindings@1.4.2-r.1": {
+      "integrity": "sha512-z0pJCdEnIj0Famkip6w7JZ/A17nm5VcYc6H7isOHXfEnPhBQ9PBusUTFgIzl6+3J8HOFQOv0szJq46zldbsHfQ==",
+      "optionalDependencies": [
+        "@duckdb/node-bindings-darwin-arm64",
+        "@duckdb/node-bindings-darwin-x64",
+        "@duckdb/node-bindings-linux-arm64",
+        "@duckdb/node-bindings-linux-x64",
+        "@duckdb/node-bindings-win32-x64"
+      ]
+    },
     "@grpc/grpc-js@1.12.6": {
       "integrity": "sha512-JXUj6PI0oqqzTGvKtzOkxtpsyPRNsrmhh41TtIz/zEB6J+AUiZZ0dxWzcMwO9Ns5rmSPuMdghlTbUuqIM48d3Q==",
       "dependencies": [
@@ -549,6 +615,13 @@
       "packages/probitas-client-sql": {
         "dependencies": [
           "jsr:@probitas/client@0"
+        ]
+      },
+      "packages/probitas-client-sql-duckdb": {
+        "dependencies": [
+          "jsr:@probitas/client-sql@0",
+          "jsr:@probitas/client@0",
+          "npm:@duckdb/node-api@1.4.2-r.1"
         ]
       },
       "packages/probitas-client-sql-mysql": {

--- a/packages/probitas-client-sql-duckdb/client.ts
+++ b/packages/probitas-client-sql-duckdb/client.ts
@@ -1,0 +1,305 @@
+import type { DuckDBConnection } from "@duckdb/node-api";
+import { DuckDBInstance } from "@duckdb/node-api";
+import {
+  SqlQueryResult,
+  type SqlTransaction,
+  type SqlTransactionOptions,
+} from "@probitas/client-sql";
+import type { DuckDbClientConfig } from "./types.ts";
+import { convertDuckDbError } from "./errors.ts";
+import {
+  DuckDbTransactionImpl,
+  type DuckDbTransactionOptions,
+} from "./transaction.ts";
+
+/**
+ * DuckDB client interface.
+ */
+export interface DuckDbClient extends AsyncDisposable {
+  /** The client configuration. */
+  readonly config: DuckDbClientConfig;
+
+  /** The SQL dialect identifier. */
+  readonly dialect: "duckdb";
+
+  /**
+   * Execute a SQL query.
+   * @param sql - SQL query string
+   * @param params - Optional query parameters
+   */
+  // deno-lint-ignore no-explicit-any
+  query<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>>;
+
+  /**
+   * Execute a query and return the first row or undefined.
+   * @param sql - SQL query string
+   * @param params - Optional query parameters
+   */
+  // deno-lint-ignore no-explicit-any
+  queryOne<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined>;
+
+  /**
+   * Execute a function within a transaction.
+   * Automatically commits on success or rolls back on error.
+   * @param fn - Function to execute within transaction
+   * @param options - Transaction options
+   */
+  transaction<T>(
+    fn: (tx: SqlTransaction) => Promise<T>,
+    options?: SqlTransactionOptions | DuckDbTransactionOptions,
+  ): Promise<T>;
+
+  /**
+   * Query a Parquet file directly.
+   * DuckDB can read Parquet files without importing them.
+   * @param path - Path to the Parquet file
+   */
+  // deno-lint-ignore no-explicit-any
+  queryParquet<T = Record<string, any>>(
+    path: string,
+  ): Promise<SqlQueryResult<T>>;
+
+  /**
+   * Query a CSV file directly.
+   * DuckDB can read CSV files without importing them.
+   * @param path - Path to the CSV file
+   */
+  // deno-lint-ignore no-explicit-any
+  queryCsv<T = Record<string, any>>(path: string): Promise<SqlQueryResult<T>>;
+
+  /**
+   * Close the database connection.
+   */
+  close(): Promise<void>;
+}
+
+/**
+ * Create a DuckDB client.
+ *
+ * @example
+ * ```typescript
+ * // Using in-memory database (default)
+ * const client = await createDuckDbClient({});
+ *
+ * // Using file-based database
+ * const client = await createDuckDbClient({
+ *   path: "./data.duckdb",
+ * });
+ *
+ * // Read-only mode
+ * const client = await createDuckDbClient({
+ *   path: "./data.duckdb",
+ *   readonly: true,
+ * });
+ *
+ * const result = await client.query<{ id: number; name: string }>(
+ *   "SELECT * FROM users WHERE id = ?",
+ *   [1],
+ * );
+ *
+ * console.log(result.rows.first()); // { id: 1, name: "Alice" }
+ *
+ * // Query Parquet file directly
+ * const parquetResult = await client.queryParquet<{ id: number; value: string }>(
+ *   "./data/events.parquet"
+ * );
+ *
+ * await client.close();
+ * ```
+ */
+export async function createDuckDbClient(
+  config: DuckDbClientConfig,
+): Promise<DuckDbClient> {
+  try {
+    // DuckDB uses :memory: for in-memory database
+    const path = config.path ?? ":memory:";
+
+    // Create instance with optional configuration
+    const instanceConfig: Record<string, string> = {};
+    if (config.readonly) {
+      instanceConfig["access_mode"] = "READ_ONLY";
+    }
+
+    const instance = await DuckDBInstance.create(
+      path,
+      Object.keys(instanceConfig).length > 0 ? instanceConfig : undefined,
+    );
+    const connection = await instance.connect();
+
+    return new DuckDbClientImpl(config, instance, connection);
+  } catch (error) {
+    throw convertDuckDbError(error);
+  }
+}
+
+class DuckDbClientImpl implements DuckDbClient {
+  readonly config: DuckDbClientConfig;
+  readonly dialect = "duckdb" as const;
+  readonly #instance: DuckDBInstance;
+  readonly #connection: DuckDBConnection;
+  #closed = false;
+
+  constructor(
+    config: DuckDbClientConfig,
+    instance: DuckDBInstance,
+    connection: DuckDBConnection,
+  ) {
+    this.config = config;
+    this.#instance = instance;
+    this.#connection = connection;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async query<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>> {
+    if (this.#closed) {
+      throw convertDuckDbError(new Error("Client is closed"));
+    }
+
+    const startTime = performance.now();
+
+    try {
+      // Check if this is a SELECT query
+      const trimmedSql = sql.trim().toUpperCase();
+      const isSelect = trimmedSql.startsWith("SELECT") ||
+        trimmedSql.startsWith("PRAGMA") ||
+        trimmedSql.startsWith("EXPLAIN") ||
+        trimmedSql.startsWith("DESCRIBE") ||
+        trimmedSql.startsWith("SHOW") ||
+        trimmedSql.startsWith("WITH");
+
+      // deno-lint-ignore no-explicit-any
+      let rows: any[];
+
+      if (params && params.length > 0) {
+        // Use prepared statement with positional parameters ($1, $2, etc.)
+        const prepared = await this.#connection.prepare(sql);
+        for (let i = 0; i < params.length; i++) {
+          const value = params[i];
+          // Bind by position (1-indexed)
+          if (value === null || value === undefined) {
+            // DuckDB node-api handles null automatically
+            prepared.bindNull(i + 1);
+          } else if (typeof value === "number") {
+            if (Number.isInteger(value)) {
+              prepared.bindInteger(i + 1, value);
+            } else {
+              prepared.bindDouble(i + 1, value);
+            }
+          } else if (typeof value === "string") {
+            prepared.bindVarchar(i + 1, value);
+          } else if (typeof value === "boolean") {
+            prepared.bindBoolean(i + 1, value);
+          } else if (typeof value === "bigint") {
+            prepared.bindBigInt(i + 1, value);
+          } else if (value instanceof Date) {
+            // DuckDB expects ISO format for dates
+            prepared.bindVarchar(i + 1, value.toISOString());
+          } else if (value instanceof Uint8Array) {
+            prepared.bindBlob(i + 1, value);
+          } else {
+            // Fallback: convert to string
+            prepared.bindVarchar(i + 1, String(value));
+          }
+        }
+        const reader = await prepared.runAndReadAll();
+        rows = reader.getRowObjects() as T[];
+      } else {
+        const reader = await this.#connection.runAndReadAll(sql);
+        rows = reader.getRowObjects() as T[];
+      }
+
+      const duration = performance.now() - startTime;
+
+      if (isSelect) {
+        return new SqlQueryResult<T>({
+          ok: true,
+          rows: rows as T[],
+          rowCount: rows.length,
+          duration,
+          metadata: {},
+        });
+      } else {
+        // For INSERT/UPDATE/DELETE queries
+        return new SqlQueryResult<T>({
+          ok: true,
+          rows: [],
+          rowCount: rows.length,
+          duration,
+          metadata: {},
+        });
+      }
+    } catch (error) {
+      throw convertDuckDbError(error);
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async queryOne<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined> {
+    const result = await this.query<T>(sql, params);
+    return result.rows.first();
+  }
+
+  async transaction<T>(
+    fn: (tx: SqlTransaction) => Promise<T>,
+    options?: SqlTransactionOptions | DuckDbTransactionOptions,
+  ): Promise<T> {
+    if (this.#closed) {
+      throw convertDuckDbError(new Error("Client is closed"));
+    }
+
+    const tx = await DuckDbTransactionImpl.begin(
+      this.#connection,
+      options as DuckDbTransactionOptions,
+    );
+
+    try {
+      const result = await fn(tx);
+      await tx.commit();
+      return result;
+    } catch (error) {
+      await tx.rollback();
+      throw error;
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  queryParquet<T = Record<string, any>>(
+    path: string,
+  ): Promise<SqlQueryResult<T>> {
+    // Escape single quotes in path
+    const escapedPath = path.replace(/'/g, "''");
+    return this.query<T>(`SELECT * FROM read_parquet('${escapedPath}')`);
+  }
+
+  // deno-lint-ignore no-explicit-any
+  queryCsv<T = Record<string, any>>(path: string): Promise<SqlQueryResult<T>> {
+    // Escape single quotes in path
+    const escapedPath = path.replace(/'/g, "''");
+    return this.query<T>(`SELECT * FROM read_csv_auto('${escapedPath}')`);
+  }
+
+  close(): Promise<void> {
+    if (this.#closed) return Promise.resolve();
+    this.#closed = true;
+    this.#connection.closeSync();
+    // Note: DuckDBInstance doesn't have an explicit close method in the API
+    // The instance is garbage collected when no longer referenced
+    return Promise.resolve();
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close();
+  }
+}

--- a/packages/probitas-client-sql-duckdb/deno.json
+++ b/packages/probitas-client-sql-duckdb/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@probitas/client-sql-duckdb",
+  "version": "0.0.0",
+  "exports": "./mod.ts",
+  "publish": {
+    "exclude": ["**/*_test.ts", "**/*_bench.ts"]
+  },
+  "imports": {
+    "@probitas/client": "jsr:@probitas/client@^0",
+    "@probitas/client-sql": "jsr:@probitas/client-sql@^0",
+    "@duckdb/node-api": "npm:@duckdb/node-api@1.4.2-r.1"
+  }
+}

--- a/packages/probitas-client-sql-duckdb/errors.ts
+++ b/packages/probitas-client-sql-duckdb/errors.ts
@@ -1,0 +1,146 @@
+import {
+  ConstraintError,
+  QuerySyntaxError,
+  SqlError,
+  type SqlErrorOptions,
+} from "@probitas/client-sql";
+
+/**
+ * DuckDB-specific error kinds.
+ */
+export type DuckDbErrorKind = "io" | "catalog" | "parser" | "binder";
+
+/**
+ * Options for DuckDbError constructor.
+ */
+export interface DuckDbErrorOptions extends SqlErrorOptions {
+  /** DuckDB error type if available. */
+  readonly errorType?: string;
+}
+
+/**
+ * Base error class for DuckDB-specific errors.
+ * Extends SqlError with DuckDB-specific properties.
+ */
+export class DuckDbError extends SqlError {
+  override readonly name: string = "DuckDbError";
+  readonly errorType?: string;
+
+  constructor(
+    message: string,
+    options?: DuckDbErrorOptions,
+  ) {
+    super(message, "unknown", options);
+    this.errorType = options?.errorType;
+  }
+}
+
+/**
+ * Error thrown for IO-related errors (file not found, permission denied, etc.).
+ */
+export class IoError extends DuckDbError {
+  override readonly name = "IoError";
+  readonly duckdbKind = "io" as const;
+
+  constructor(message: string, options?: DuckDbErrorOptions) {
+    super(message, options);
+  }
+}
+
+/**
+ * Error thrown for catalog errors (table not found, etc.).
+ */
+export class CatalogError extends DuckDbError {
+  override readonly name = "CatalogError";
+  readonly duckdbKind = "catalog" as const;
+
+  constructor(message: string, options?: DuckDbErrorOptions) {
+    super(message, options);
+  }
+}
+
+/**
+ * Convert a DuckDB error to the appropriate error class.
+ *
+ * DuckDB errors are classified based on message content analysis.
+ */
+export function convertDuckDbError(error: unknown): SqlError {
+  if (!(error instanceof Error)) {
+    return new DuckDbError(String(error));
+  }
+
+  const options: DuckDbErrorOptions = {
+    cause: error,
+  };
+
+  const message = error.message.toLowerCase();
+
+  // Check for constraint violations
+  if (
+    message.includes("constraint") ||
+    message.includes("duplicate key") ||
+    message.includes("unique") ||
+    message.includes("foreign key") ||
+    message.includes("not null")
+  ) {
+    let constraint = "unknown";
+
+    // Try to extract constraint information
+    const uniqueMatch = error.message.match(/unique constraint/i);
+    if (uniqueMatch) {
+      constraint = "UNIQUE";
+    }
+
+    const fkMatch = error.message.match(/foreign key/i);
+    if (fkMatch) {
+      constraint = "FOREIGN KEY";
+    }
+
+    const pkMatch = error.message.match(/primary key/i);
+    if (pkMatch) {
+      constraint = "PRIMARY KEY";
+    }
+
+    const notNullMatch = error.message.match(/not null/i);
+    if (notNullMatch) {
+      constraint = "NOT NULL";
+    }
+
+    return new ConstraintError(error.message, constraint, options);
+  }
+
+  // Check for IO errors (before syntax errors, as "file not found" is more specific)
+  if (
+    message.includes("io error") ||
+    message.includes("permission denied") ||
+    message.includes("no such file") ||
+    message.includes("file not found") ||
+    message.includes("cannot open")
+  ) {
+    return new IoError(error.message, options);
+  }
+
+  // Check for syntax/parser errors
+  if (
+    message.includes("parser error") ||
+    message.includes("syntax error") ||
+    message.includes("binder error") ||
+    message.includes("catalog error") ||
+    message.includes("does not exist") ||
+    message.includes("invalid") ||
+    message.includes("expected")
+  ) {
+    // Catalog-specific errors
+    if (
+      message.includes("catalog error") ||
+      message.includes("does not exist") ||
+      message.includes("table") && message.includes("not found")
+    ) {
+      return new CatalogError(error.message, options);
+    }
+
+    return new QuerySyntaxError(error.message, options);
+  }
+
+  return new DuckDbError(error.message, options);
+}

--- a/packages/probitas-client-sql-duckdb/errors_test.ts
+++ b/packages/probitas-client-sql-duckdb/errors_test.ts
@@ -1,0 +1,153 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { SqlError } from "@probitas/client-sql";
+import {
+  CatalogError,
+  convertDuckDbError,
+  DuckDbError,
+  IoError,
+} from "./errors.ts";
+
+Deno.test("DuckDbError", async (t) => {
+  await t.step("extends SqlError", () => {
+    const error = new DuckDbError("test error");
+    assertInstanceOf(error, SqlError);
+    assertInstanceOf(error, Error);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new DuckDbError("test error", {
+      errorType: "PARSER",
+    });
+
+    assertEquals(error.name, "DuckDbError");
+    assertEquals(error.message, "test error");
+    assertEquals(error.kind, "unknown");
+    assertEquals(error.errorType, "PARSER");
+  });
+
+  await t.step("supports error chaining", () => {
+    const cause = new Error("original error");
+    const error = new DuckDbError("wrapped", { cause });
+
+    assertEquals(error.cause, cause);
+  });
+});
+
+Deno.test("IoError", async (t) => {
+  await t.step("extends DuckDbError with io duckdbKind", () => {
+    const error = new IoError("file not found", {
+      errorType: "IO",
+    });
+
+    assertInstanceOf(error, DuckDbError);
+    assertEquals(error.name, "IoError");
+    assertEquals(error.duckdbKind, "io");
+    assertEquals(error.errorType, "IO");
+  });
+});
+
+Deno.test("CatalogError", async (t) => {
+  await t.step("extends DuckDbError with catalog duckdbKind", () => {
+    const error = new CatalogError("table not found");
+
+    assertInstanceOf(error, DuckDbError);
+    assertEquals(error.name, "CatalogError");
+    assertEquals(error.duckdbKind, "catalog");
+  });
+});
+
+Deno.test("convertDuckDbError", async (t) => {
+  await t.step("handles non-Error values", () => {
+    const error = convertDuckDbError("string error");
+
+    assertInstanceOf(error, DuckDbError);
+    assertEquals(error.message, "string error");
+    assertEquals(error.kind, "unknown");
+  });
+
+  await t.step("converts 'parser error' message to QuerySyntaxError", () => {
+    const duckdbError = new Error("Parser Error: syntax error at or near");
+
+    const error = convertDuckDbError(duckdbError);
+
+    assertEquals(error.kind, "query");
+  });
+
+  await t.step("converts 'binder error' message to QuerySyntaxError", () => {
+    const duckdbError = new Error("Binder Error: could not resolve column");
+
+    const error = convertDuckDbError(duckdbError);
+
+    assertEquals(error.kind, "query");
+  });
+
+  await t.step("converts 'catalog error' message to CatalogError", () => {
+    const duckdbError = new Error("Catalog Error: table does not exist");
+
+    const error = convertDuckDbError(duckdbError);
+
+    assertInstanceOf(error, CatalogError);
+    assertEquals((error as CatalogError).duckdbKind, "catalog");
+  });
+
+  await t.step(
+    "converts 'table does not exist' message to CatalogError",
+    () => {
+      const duckdbError = new Error("Table 'users' does not exist");
+
+      const error = convertDuckDbError(duckdbError);
+
+      assertInstanceOf(error, CatalogError);
+    },
+  );
+
+  await t.step("converts constraint violation to ConstraintError", () => {
+    const duckdbError = new Error("Constraint Error: UNIQUE constraint failed");
+
+    const error = convertDuckDbError(duckdbError);
+
+    assertEquals(error.kind, "constraint");
+  });
+
+  await t.step("converts foreign key violation to ConstraintError", () => {
+    const duckdbError = new Error("Constraint Error: FOREIGN KEY violation");
+
+    const error = convertDuckDbError(duckdbError);
+
+    assertEquals(error.kind, "constraint");
+  });
+
+  await t.step("converts io error to IoError", () => {
+    const duckdbError = new Error("IO Error: file not found");
+
+    const error = convertDuckDbError(duckdbError);
+
+    assertInstanceOf(error, IoError);
+    assertEquals((error as IoError).duckdbKind, "io");
+  });
+
+  await t.step("converts permission denied to IoError", () => {
+    const duckdbError = new Error("Permission denied: cannot open file");
+
+    const error = convertDuckDbError(duckdbError);
+
+    assertInstanceOf(error, IoError);
+  });
+
+  await t.step("preserves cause in converted error", () => {
+    const originalError = new Error("Catalog Error: table not found");
+
+    const error = convertDuckDbError(originalError);
+
+    assertEquals(error.cause, originalError);
+  });
+
+  await t.step("returns DuckDbError for unknown errors", () => {
+    const duckdbError = new Error("Unknown internal error");
+
+    const error = convertDuckDbError(duckdbError);
+
+    assertInstanceOf(error, DuckDbError);
+    assertEquals(error.kind, "unknown");
+  });
+});

--- a/packages/probitas-client-sql-duckdb/integration_test.ts
+++ b/packages/probitas-client-sql-duckdb/integration_test.ts
@@ -1,0 +1,504 @@
+import { assertEquals, assertRejects } from "@std/assert";
+
+/**
+ * Check if DuckDB native library is available.
+ * The @duckdb/node-api package requires the DuckDB C library to be installed.
+ * We use dynamic import to prevent module load errors.
+ */
+async function isDuckDbAvailable(): Promise<boolean> {
+  try {
+    const { createDuckDbClient } = await import("./mod.ts");
+    const client = await createDuckDbClient({});
+    await client.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const duckDbAvailable = await isDuckDbAvailable();
+
+Deno.test({
+  name: "Integration: DuckDbClient",
+  ignore: !duckDbAvailable,
+  async fn(t) {
+    // Dynamic import to avoid module load errors when DuckDB is not available
+    const {
+      createDuckDbClient,
+      expectSqlQueryResult,
+      QuerySyntaxError,
+      ConstraintError,
+    } = await import("./mod.ts");
+    type DuckDbClient = Awaited<ReturnType<typeof createDuckDbClient>>;
+
+    await t.step("has dialect property", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        assertEquals(client.dialect, "duckdb");
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("executes simple SELECT query", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        const result = await client.query<{ value: number }>(
+          "SELECT 1 as value",
+        );
+
+        assertEquals(result.ok, true);
+        assertEquals(result.rows.first(), { value: 1 });
+        assertEquals(result.rowCount, 1);
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("executes query with parameters", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        const result = await client.query<{ a: number; b: string }>(
+          "SELECT $1::INTEGER as a, $2::VARCHAR as b",
+          [42, "hello"],
+        );
+
+        assertEquals(result.rows.first(), { a: 42, b: "hello" });
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("creates table and inserts data", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        await client.query(`
+          CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            name VARCHAR NOT NULL,
+            email VARCHAR UNIQUE
+          )
+        `);
+
+        const insertResult = await client.query(
+          "INSERT INTO users (id, name, email) VALUES ($1, $2, $3)",
+          [1, "Alice", "alice@example.com"],
+        );
+
+        assertEquals(insertResult.ok, true);
+
+        const selectResult = await client.query<
+          { id: number; name: string; email: string }
+        >(
+          "SELECT * FROM users WHERE id = $1",
+          [1],
+        );
+
+        assertEquals(selectResult.rows.first(), {
+          id: 1,
+          name: "Alice",
+          email: "alice@example.com",
+        });
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("queryOne returns first row or undefined", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        await client.query(
+          "CREATE TABLE items (id INTEGER PRIMARY KEY, value VARCHAR)",
+        );
+
+        const empty = await client.queryOne<{ id: number; value: string }>(
+          "SELECT * FROM items WHERE id = $1",
+          [999],
+        );
+        assertEquals(empty, undefined);
+
+        await client.query(
+          "INSERT INTO items (id, value) VALUES ($1, $2)",
+          [1, "test"],
+        );
+
+        const found = await client.queryOne<{ id: number; value: string }>(
+          "SELECT * FROM items WHERE id = $1",
+          [1],
+        );
+        assertEquals(found, { id: 1, value: "test" });
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("handles syntax errors", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        await assertRejects(
+          () => client.query("SELEC * FROM users"),
+          QuerySyntaxError,
+        );
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("handles constraint violations", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        await client.query(`
+          CREATE TABLE unique_test (
+            id INTEGER PRIMARY KEY,
+            code VARCHAR UNIQUE
+          )
+        `);
+
+        await client.query(
+          "INSERT INTO unique_test (id, code) VALUES ($1, $2)",
+          [1, "ABC"],
+        );
+
+        await assertRejects(
+          () =>
+            client.query(
+              "INSERT INTO unique_test (id, code) VALUES ($1, $2)",
+              [2, "ABC"],
+            ),
+          ConstraintError,
+        );
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("transaction commits on success", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        await client.query(
+          "CREATE TABLE tx_test (id INTEGER PRIMARY KEY, value VARCHAR)",
+        );
+
+        await client.transaction(async (tx) => {
+          await tx.query("INSERT INTO tx_test (id, value) VALUES ($1, $2)", [
+            1,
+            "one",
+          ]);
+          await tx.query("INSERT INTO tx_test (id, value) VALUES ($1, $2)", [
+            2,
+            "two",
+          ]);
+        });
+
+        const result = await client.query<{ id: number; value: string }>(
+          "SELECT * FROM tx_test ORDER BY id",
+        );
+
+        assertEquals(result.rows.length, 2);
+        assertEquals(result.rows[0].value, "one");
+        assertEquals(result.rows[1].value, "two");
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("transaction rolls back on error", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        await client.query(
+          "CREATE TABLE rollback_test (id INTEGER PRIMARY KEY, value VARCHAR)",
+        );
+
+        try {
+          await client.transaction(async (tx) => {
+            await tx.query(
+              "INSERT INTO rollback_test (id, value) VALUES ($1, $2)",
+              [1, "should rollback"],
+            );
+            throw new Error("Intentional error");
+          });
+        } catch {
+          // Expected
+        }
+
+        const result = await client.query<{ id: number; value: string }>(
+          "SELECT * FROM rollback_test",
+        );
+
+        assertEquals(result.rows.length, 0);
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("supports AsyncDisposable", async () => {
+      let clientRef: DuckDbClient | undefined;
+
+      {
+        await using client = await createDuckDbClient({});
+        clientRef = client;
+
+        const result = await client.query("SELECT 1 as value");
+        assertEquals(result.ok, true);
+      }
+
+      // After the block, client should be closed
+      // Attempting to use it should throw
+      if (clientRef) {
+        await assertRejects(
+          () => clientRef!.query("SELECT 1"),
+          Error,
+          "Client is closed",
+        );
+      }
+    });
+
+    await t.step(
+      "expectSqlQueryResult works with DuckDB results",
+      async () => {
+        const client = await createDuckDbClient({});
+
+        try {
+          await client.query(`
+            CREATE TABLE expect_test (
+              id INTEGER PRIMARY KEY,
+              name VARCHAR
+            )
+          `);
+
+          await client.query(
+            "INSERT INTO expect_test (id, name) VALUES ($1, $2)",
+            [1, "Alice"],
+          );
+          await client.query(
+            "INSERT INTO expect_test (id, name) VALUES ($1, $2)",
+            [2, "Bob"],
+          );
+
+          const result = await client.query<{ id: number; name: string }>(
+            "SELECT * FROM expect_test ORDER BY id",
+          );
+
+          expectSqlQueryResult(result)
+            .ok()
+            .hasContent()
+            .rows(2)
+            .rowContains({ name: "Alice" });
+        } finally {
+          await client.close();
+        }
+      },
+    );
+
+    await t.step("DuckDB specific: analytical queries", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        await client.query(`
+          CREATE TABLE sales (
+            product VARCHAR,
+            amount DECIMAL(10,2),
+            date DATE
+          )
+        `);
+
+        await client.query(
+          "INSERT INTO sales VALUES ($1, $2, $3)",
+          ["Widget", 100.00, "2024-01-01"],
+        );
+        await client.query(
+          "INSERT INTO sales VALUES ($1, $2, $3)",
+          ["Widget", 150.00, "2024-01-02"],
+        );
+        await client.query(
+          "INSERT INTO sales VALUES ($1, $2, $3)",
+          ["Gadget", 200.00, "2024-01-01"],
+        );
+
+        // DuckDB excels at analytical queries
+        const result = await client.query<{ product: string; total: number }>(
+          `SELECT product, SUM(amount) as total
+           FROM sales
+           GROUP BY product
+           ORDER BY total DESC`,
+        );
+
+        assertEquals(result.rows.length, 2);
+        assertEquals(result.rows[0].product, "Widget");
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("DuckDB specific: window functions", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        await client.query(`
+          CREATE TABLE events (
+            id INTEGER,
+            category VARCHAR,
+            value INTEGER
+          )
+        `);
+
+        await client.query("INSERT INTO events VALUES (1, 'A', 10)");
+        await client.query("INSERT INTO events VALUES (2, 'A', 20)");
+        await client.query("INSERT INTO events VALUES (3, 'B', 30)");
+
+        const result = await client.query<{
+          id: number;
+          category: string;
+          value: number;
+          running_total: bigint;
+        }>(
+          `SELECT id, category, value,
+                  SUM(value) OVER (PARTITION BY category ORDER BY id) as running_total
+           FROM events
+           ORDER BY id`,
+        );
+
+        assertEquals(result.rows.length, 3);
+        assertEquals(result.rows[0].running_total, 10n);
+        assertEquals(result.rows[1].running_total, 30n);
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step("DuckDB specific: queryCsv reads CSV file", async () => {
+      const client = await createDuckDbClient({});
+      const csvPath = await Deno.makeTempFile({ suffix: ".csv" });
+
+      try {
+        // Create a CSV file
+        await Deno.writeTextFile(
+          csvPath,
+          "id,name,value\n1,Alice,100\n2,Bob,200\n",
+        );
+
+        const result = await client.queryCsv<{
+          id: number;
+          name: string;
+          value: number;
+        }>(csvPath);
+
+        assertEquals(result.ok, true);
+        assertEquals(result.rows.length, 2);
+        assertEquals(result.rows[0].name, "Alice");
+        assertEquals(result.rows[1].name, "Bob");
+      } finally {
+        await client.close();
+        await Deno.remove(csvPath);
+      }
+    });
+
+    await t.step(
+      "DuckDB specific: queryParquet reads Parquet file",
+      async () => {
+        const client = await createDuckDbClient({});
+        const parquetPath = await Deno.makeTempFile({ suffix: ".parquet" });
+
+        try {
+          // Create a Parquet file using DuckDB's COPY command
+          await client.query(`
+          CREATE TABLE parquet_source (id INTEGER, name VARCHAR, value INTEGER)
+        `);
+          await client.query(
+            "INSERT INTO parquet_source VALUES (1, 'Alice', 100)",
+          );
+          await client.query(
+            "INSERT INTO parquet_source VALUES (2, 'Bob', 200)",
+          );
+          await client.query(
+            `COPY parquet_source TO '${
+              parquetPath.replace(/'/g, "''")
+            }' (FORMAT PARQUET)`,
+          );
+
+          const result = await client.queryParquet<{
+            id: number;
+            name: string;
+            value: number;
+          }>(parquetPath);
+
+          assertEquals(result.ok, true);
+          assertEquals(result.rows.length, 2);
+          assertEquals(result.rows[0].name, "Alice");
+          assertEquals(result.rows[1].name, "Bob");
+        } finally {
+          await client.close();
+          await Deno.remove(parquetPath);
+        }
+      },
+    );
+
+    await t.step("DuckDB specific: JSON data types", async () => {
+      const client = await createDuckDbClient({});
+
+      try {
+        await client.query(`
+          CREATE TABLE json_test (
+            id INTEGER PRIMARY KEY,
+            data JSON
+          )
+        `);
+
+        await client.query(
+          "INSERT INTO json_test VALUES ($1, $2::JSON)",
+          [1, '{"name": "Alice", "age": 30}'],
+        );
+
+        const result = await client.query<{ id: number; data: string }>(
+          "SELECT id, data::VARCHAR as data FROM json_test WHERE id = $1",
+          [1],
+        );
+
+        assertEquals(result.rows.length, 1);
+        const parsed = JSON.parse(result.rows[0].data);
+        assertEquals(parsed.name, "Alice");
+        assertEquals(parsed.age, 30);
+      } finally {
+        await client.close();
+      }
+    });
+
+    await t.step(
+      "DuckDB specific: CTE (Common Table Expressions)",
+      async () => {
+        const client = await createDuckDbClient({});
+
+        try {
+          const result = await client.query<{
+            n: number | bigint;
+            factorial: number | bigint;
+          }>(`
+          WITH RECURSIVE factorial(n, fact) AS (
+            SELECT 1, 1
+            UNION ALL
+            SELECT n + 1, fact * (n + 1)
+            FROM factorial
+            WHERE n < 5
+          )
+          SELECT n, fact as factorial FROM factorial
+        `);
+
+          assertEquals(result.rows.length, 5);
+          // DuckDB may return number or bigint depending on the computation
+          assertEquals(Number(result.rows[4].factorial), 120); // 5! = 120
+        } finally {
+          await client.close();
+        }
+      },
+    );
+  },
+});

--- a/packages/probitas-client-sql-duckdb/mod.ts
+++ b/packages/probitas-client-sql-duckdb/mod.ts
@@ -1,0 +1,14 @@
+// Client
+export * from "./client.ts";
+
+// Transaction
+export type * from "./transaction.ts";
+
+// Types
+export type * from "./types.ts";
+
+// Errors
+export * from "./errors.ts";
+
+// Re-export common types from @probitas/client-sql
+export * from "@probitas/client-sql";

--- a/packages/probitas-client-sql-duckdb/transaction.ts
+++ b/packages/probitas-client-sql-duckdb/transaction.ts
@@ -1,0 +1,162 @@
+import type { DuckDBConnection } from "@duckdb/node-api";
+import {
+  SqlQueryResult,
+  type SqlTransaction,
+  type SqlTransactionOptions,
+} from "@probitas/client-sql";
+import { convertDuckDbError } from "./errors.ts";
+
+/**
+ * DuckDB-specific transaction options.
+ */
+export interface DuckDbTransactionOptions extends SqlTransactionOptions {
+  // DuckDB uses standard isolation levels, no custom options needed
+}
+
+export class DuckDbTransactionImpl implements SqlTransaction {
+  readonly #conn: DuckDBConnection;
+  #finished = false;
+
+  private constructor(conn: DuckDBConnection) {
+    this.#conn = conn;
+  }
+
+  /**
+   * Begin a new transaction.
+   */
+  static async begin(
+    conn: DuckDBConnection,
+    _options?: DuckDbTransactionOptions,
+  ): Promise<DuckDbTransactionImpl> {
+    try {
+      // DuckDB uses "BEGIN TRANSACTION" and doesn't support
+      // isolation level syntax in BEGIN statement directly.
+      // It operates with snapshot isolation by default.
+      await conn.run("BEGIN TRANSACTION");
+      return new DuckDbTransactionImpl(conn);
+    } catch (error) {
+      throw convertDuckDbError(error);
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async query<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<SqlQueryResult<T>> {
+    if (this.#finished) {
+      throw convertDuckDbError(new Error("Transaction is already finished"));
+    }
+
+    const startTime = performance.now();
+
+    try {
+      // Check if this is a SELECT query
+      const trimmedSql = sql.trim().toUpperCase();
+      const isSelect = trimmedSql.startsWith("SELECT") ||
+        trimmedSql.startsWith("PRAGMA") ||
+        trimmedSql.startsWith("EXPLAIN") ||
+        trimmedSql.startsWith("DESCRIBE") ||
+        trimmedSql.startsWith("SHOW") ||
+        trimmedSql.startsWith("WITH");
+
+      // deno-lint-ignore no-explicit-any
+      let rows: any[];
+
+      if (params && params.length > 0) {
+        // Use prepared statement with positional parameters ($1, $2, etc.)
+        const prepared = await this.#conn.prepare(sql);
+        for (let i = 0; i < params.length; i++) {
+          const value = params[i];
+          // Bind by position (1-indexed)
+          if (value === null || value === undefined) {
+            prepared.bindNull(i + 1);
+          } else if (typeof value === "number") {
+            if (Number.isInteger(value)) {
+              prepared.bindInteger(i + 1, value);
+            } else {
+              prepared.bindDouble(i + 1, value);
+            }
+          } else if (typeof value === "string") {
+            prepared.bindVarchar(i + 1, value);
+          } else if (typeof value === "boolean") {
+            prepared.bindBoolean(i + 1, value);
+          } else if (typeof value === "bigint") {
+            prepared.bindBigInt(i + 1, value);
+          } else if (value instanceof Date) {
+            // DuckDB expects ISO format for dates
+            prepared.bindVarchar(i + 1, value.toISOString());
+          } else if (value instanceof Uint8Array) {
+            prepared.bindBlob(i + 1, value);
+          } else {
+            // Fallback: convert to string
+            prepared.bindVarchar(i + 1, String(value));
+          }
+        }
+        const reader = await prepared.runAndReadAll();
+        rows = reader.getRowObjects() as T[];
+      } else {
+        const reader = await this.#conn.runAndReadAll(sql);
+        rows = reader.getRowObjects() as T[];
+      }
+
+      const duration = performance.now() - startTime;
+
+      if (isSelect) {
+        return new SqlQueryResult<T>({
+          ok: true,
+          rows: rows as T[],
+          rowCount: rows.length,
+          duration,
+          metadata: {},
+        });
+      } else {
+        // For INSERT/UPDATE/DELETE, rows will be empty
+        return new SqlQueryResult<T>({
+          ok: true,
+          rows: [],
+          rowCount: rows.length,
+          duration,
+          metadata: {},
+        });
+      }
+    } catch (error) {
+      throw convertDuckDbError(error);
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async queryOne<T = Record<string, any>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T | undefined> {
+    const result = await this.query<T>(sql, params);
+    return result.rows.first();
+  }
+
+  async commit(): Promise<void> {
+    if (this.#finished) {
+      throw convertDuckDbError(new Error("Transaction is already finished"));
+    }
+
+    try {
+      await this.#conn.run("COMMIT");
+      this.#finished = true;
+    } catch (error) {
+      throw convertDuckDbError(error);
+    }
+  }
+
+  async rollback(): Promise<void> {
+    if (this.#finished) {
+      throw convertDuckDbError(new Error("Transaction is already finished"));
+    }
+
+    try {
+      await this.#conn.run("ROLLBACK");
+      this.#finished = true;
+    } catch (error) {
+      throw convertDuckDbError(error);
+    }
+  }
+}

--- a/packages/probitas-client-sql-duckdb/types.ts
+++ b/packages/probitas-client-sql-duckdb/types.ts
@@ -1,0 +1,18 @@
+import type { CommonOptions } from "@probitas/client";
+
+/**
+ * Configuration for creating a DuckDB client.
+ */
+export interface DuckDbClientConfig extends CommonOptions {
+  /**
+   * Database file path.
+   * Use `:memory:` or omit for an in-memory database.
+   */
+  readonly path?: string;
+
+  /**
+   * Open the database in read-only mode.
+   * @default false
+   */
+  readonly readonly?: boolean;
+}


### PR DESCRIPTION
## Summary
- Add DuckDB SQL client using official `@duckdb/node-api` package
- Support query execution with PostgreSQL-style positional parameters (`$1`, `$2`, ...)
- Include CSV and Parquet file direct querying capabilities
- Comprehensive error handling (syntax, constraint, connection errors)
- Transaction support with automatic commit/rollback

## Test plan
- [x] Unit tests for error classes pass
- [x] Integration tests with in-memory DuckDB pass
- [x] All 17 DuckDB-specific test cases verified
- [x] CI workflow updated with libduckdb installation step