### PR TITLE
feat(sqs): add probitas-client-sqs package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,18 @@ jobs:
           --health-interval 10s
           --health-timeout 10s
           --health-retries 10
+      localstack:
+        image: localstack/localstack:latest
+        ports:
+          - 4566:4566
+        env:
+          SERVICES: sqs
+          DEBUG: 0
+        options: >-
+          --health-cmd "curl -f http://localhost:4566/_localstack/health || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     env:
       DENO_KV_ACCESS_TOKEN: testtoken1234
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ When adding a new integration test:
 | client-grpc    | echo-grpc    | `ghcr.io/jsr-probitas/echo-grpc`    | 50051      | 50051   |
 | client-graphql | echo-graphql | `ghcr.io/jsr-probitas/echo-graphql` | 14000      | 14000   |
 | client-redis   | redis        | `redis:7`                           | 16379      | 16379   |
+| client-sqs     | localstack   | `localstack/localstack`             | 4566       | 4566    |
 
 Example `compose.yaml` structure:
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -121,3 +121,17 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
+  # LocalStack for AWS services (SQS) integration testing
+  localstack:
+    image: localstack/localstack:latest
+    ports:
+      - "4566:4566"
+    environment:
+      SERVICES: sqs
+      DEBUG: 0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -12,7 +12,8 @@
     "./packages/probitas-client-sql-duckdb",
     "./packages/probitas-client-sql-mysql",
     "./packages/probitas-client-sql-postgres",
-    "./packages/probitas-client-sql-sqlite"
+    "./packages/probitas-client-sql-sqlite",
+    "./packages/probitas-client-sqs"
   ],
   "unstable": ["kv"],
   "exclude": [
@@ -43,6 +44,7 @@
     "jsr:@probitas/client-sql-duckdb@^0": "./packages/probitas-client-sql-duckdb/mod.ts",
     "jsr:@probitas/client-sql-mysql@^0": "./packages/probitas-client-sql-mysql/mod.ts",
     "jsr:@probitas/client-sql-postgres@^0": "./packages/probitas-client-sql-postgres/mod.ts",
-    "jsr:@probitas/client-sql-sqlite@^0": "./packages/probitas-client-sql-sqlite/mod.ts"
+    "jsr:@probitas/client-sql-sqlite@^0": "./packages/probitas-client-sql-sqlite/mod.ts",
+    "jsr:@probitas/client-sqs@^0": "./packages/probitas-client-sqs/mod.ts"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -23,6 +23,7 @@
     "jsr:@std/path@^1.1.3": "1.1.3",
     "jsr:@std/semver@^1.0.4": "1.0.7",
     "jsr:@std/testing@^1.0.16": "1.0.16",
+    "npm:@aws-sdk/client-sqs@^3.700.0": "3.940.0",
     "npm:@duckdb/node-api@1.4.2-r.1": "1.4.2-r.1",
     "npm:@grpc/grpc-js@1.12": "1.12.6",
     "npm:@grpc/proto-loader@0.7": "0.7.15",
@@ -123,6 +124,425 @@
     }
   },
   "npm": {
+    "@aws-crypto/sha256-browser@5.2.0": {
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": [
+        "@aws-crypto/sha256-js",
+        "@aws-crypto/supports-web-crypto",
+        "@aws-crypto/util",
+        "@aws-sdk/types",
+        "@aws-sdk/util-locate-window",
+        "@smithy/util-utf8@2.3.0",
+        "tslib"
+      ]
+    },
+    "@aws-crypto/sha256-js@5.2.0": {
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": [
+        "@aws-crypto/util",
+        "@aws-sdk/types",
+        "tslib"
+      ]
+    },
+    "@aws-crypto/supports-web-crypto@5.2.0": {
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@aws-crypto/util@5.2.0": {
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/util-utf8@2.3.0",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/client-sqs@3.940.0": {
+      "integrity": "sha512-tXPi9OlELbiewGDb9maXDMhdYW617I9osGo/C1GAR6eLYwj40/TfOBeOQf3tX9EcH8NpDBuMksxoAvkpvqYIKw==",
+      "dependencies": [
+        "@aws-crypto/sha256-browser",
+        "@aws-crypto/sha256-js",
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-node",
+        "@aws-sdk/middleware-host-header",
+        "@aws-sdk/middleware-logger",
+        "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-sdk-sqs",
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/region-config-resolver",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-user-agent-browser",
+        "@aws-sdk/util-user-agent-node",
+        "@smithy/config-resolver",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/hash-node",
+        "@smithy/invalid-dependency",
+        "@smithy/md5-js",
+        "@smithy/middleware-content-length",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-retry",
+        "@smithy/middleware-serde",
+        "@smithy/middleware-stack",
+        "@smithy/node-config-provider",
+        "@smithy/node-http-handler",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-body-length-node",
+        "@smithy/util-defaults-mode-browser",
+        "@smithy/util-defaults-mode-node",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/client-sso@3.940.0": {
+      "integrity": "sha512-SdqJGWVhmIURvCSgkDditHRO+ozubwZk9aCX9MK8qxyOndhobCndW1ozl3hX9psvMAo9Q4bppjuqy/GHWpjB+A==",
+      "dependencies": [
+        "@aws-crypto/sha256-browser",
+        "@aws-crypto/sha256-js",
+        "@aws-sdk/core",
+        "@aws-sdk/middleware-host-header",
+        "@aws-sdk/middleware-logger",
+        "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/region-config-resolver",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-user-agent-browser",
+        "@aws-sdk/util-user-agent-node",
+        "@smithy/config-resolver",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/hash-node",
+        "@smithy/invalid-dependency",
+        "@smithy/middleware-content-length",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-retry",
+        "@smithy/middleware-serde",
+        "@smithy/middleware-stack",
+        "@smithy/node-config-provider",
+        "@smithy/node-http-handler",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-body-length-node",
+        "@smithy/util-defaults-mode-browser",
+        "@smithy/util-defaults-mode-node",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/core@3.940.0": {
+      "integrity": "sha512-KsGD2FLaX5ngJao1mHxodIVU9VYd1E8810fcYiGwO1PFHDzf5BEkp6D9IdMeQwT8Q6JLYtiiT1Y/o3UCScnGoA==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@aws-sdk/xml-builder",
+        "@smithy/core",
+        "@smithy/node-config-provider",
+        "@smithy/property-provider",
+        "@smithy/protocol-http",
+        "@smithy/signature-v4",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "@smithy/util-middleware",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-env@3.940.0": {
+      "integrity": "sha512-/G3l5/wbZYP2XEQiOoIkRJmlv15f1P3MSd1a0gz27lHEMrOJOGq66rF1Ca4OJLzapWt3Fy9BPrZAepoAX11kMw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-http@3.940.0": {
+      "integrity": "sha512-dOrc03DHElNBD6N9Okt4U0zhrG4Wix5QUBSZPr5VN8SvmjD9dkrrxOkkJaMCl/bzrW7kbQEp7LuBdbxArMmOZQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/property-provider",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-stream",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-ini@3.940.0": {
+      "integrity": "sha512-gn7PJQEzb/cnInNFTOaDoCN/hOKqMejNmLof1W5VW95Qk0TPO52lH8R4RmJPnRrwFMswOWswTOpR1roKNLIrcw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-login",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/credential-provider-imds",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-login@3.940.0": {
+      "integrity": "sha512-fOKC3VZkwa9T2l2VFKWRtfHQPQuISqqNl35ZhcXjWKVwRwl/o7THPMkqI4XwgT2noGa7LLYVbWMwnsgSsBqglg==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/protocol-http",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-node@3.940.0": {
+      "integrity": "sha512-M8NFAvgvO6xZjiti5kztFiAYmSmSlG3eUfr4ZHSfXYZUA/KUdZU/D6xJyaLnU8cYRWBludb6K9XPKKVwKfqm4g==",
+      "dependencies": [
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-ini",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/types",
+        "@smithy/credential-provider-imds",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-process@3.940.0": {
+      "integrity": "sha512-pILBzt5/TYCqRsJb7vZlxmRIe0/T+FZPeml417EK75060ajDGnVJjHcuVdLVIeKoTKm9gmJc9l45gon6PbHyUQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-sso@3.940.0": {
+      "integrity": "sha512-q6JMHIkBlDCOMnA3RAzf8cGfup+8ukhhb50fNpghMs1SNBGhanmaMbZSgLigBRsPQW7fOk2l8jnzdVLS+BB9Uw==",
+      "dependencies": [
+        "@aws-sdk/client-sso",
+        "@aws-sdk/core",
+        "@aws-sdk/token-providers",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-web-identity@3.940.0": {
+      "integrity": "sha512-9QLTIkDJHHaYL0nyymO41H8g3ui1yz6Y3GmAN1gYQa6plXisuFBnGAbmKVj7zNvjWaOKdF0dV3dd3AFKEDoJ/w==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-host-header@3.936.0": {
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-logger@3.936.0": {
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-recursion-detection@3.936.0": {
+      "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@aws/lambda-invoke-store",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-sdk-sqs@3.936.0": {
+      "integrity": "sha512-39WohFCCPeD6LV8zLQq7CyYbIieetEDDNLsEPeGJSh2Uv9qpY9r6zJRSTjb8hTuQbHDSEOGntHMYKpLoHdoxdQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-hex-encoding",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-user-agent@3.940.0": {
+      "integrity": "sha512-nJbLrUj6fY+l2W2rIB9P4Qvpiy0tnTdg/dmixRxrU1z3e8wBdspJlyE+AZN4fuVbeL6rrRrO/zxQC1bB3cw5IA==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@smithy/core",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/nested-clients@3.940.0": {
+      "integrity": "sha512-x0mdv6DkjXqXEcQj3URbCltEzW6hoy/1uIL+i8gExP6YKrnhiZ7SzuB4gPls2UOpK5UqLiqXjhRLfBb1C9i4Dw==",
+      "dependencies": [
+        "@aws-crypto/sha256-browser",
+        "@aws-crypto/sha256-js",
+        "@aws-sdk/core",
+        "@aws-sdk/middleware-host-header",
+        "@aws-sdk/middleware-logger",
+        "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/region-config-resolver",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-user-agent-browser",
+        "@aws-sdk/util-user-agent-node",
+        "@smithy/config-resolver",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/hash-node",
+        "@smithy/invalid-dependency",
+        "@smithy/middleware-content-length",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-retry",
+        "@smithy/middleware-serde",
+        "@smithy/middleware-stack",
+        "@smithy/node-config-provider",
+        "@smithy/node-http-handler",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-body-length-node",
+        "@smithy/util-defaults-mode-browser",
+        "@smithy/util-defaults-mode-node",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/region-config-resolver@3.936.0": {
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/config-resolver",
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/token-providers@3.940.0": {
+      "integrity": "sha512-k5qbRe/ZFjW9oWEdzLIa2twRVIEx7p/9rutofyrRysrtEnYh3HAWCngAnwbgKMoiwa806UzcTRx0TjyEpnKcCg==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/types@3.936.0": {
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-endpoints@3.936.0": {
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-endpoints",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-locate-window@3.893.0": {
+      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-user-agent-browser@3.936.0": {
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/types",
+        "bowser",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-user-agent-node@3.940.0": {
+      "integrity": "sha512-dlD/F+L/jN26I8Zg5x0oDGJiA+/WEQmnSE27fi5ydvYnpfQLwThtQo9SsNS47XSR/SOULaaoC9qx929rZuo74A==",
+      "dependencies": [
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/types",
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/xml-builder@3.930.0": {
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "dependencies": [
+        "@smithy/types",
+        "fast-xml-parser",
+        "tslib"
+      ]
+    },
+    "@aws/lambda-invoke-store@0.2.1": {
+      "integrity": "sha512-sIyFcoPZkTtNu9xFeEoynMef3bPJIAbOfUh+ueYcfhVl6xm2VRtMcMclSxmZCMnHHd4hlYKJeq/aggmBEWynww=="
+    },
     "@duckdb/node-api@1.4.2-r.1": {
       "integrity": "sha512-8Ef4R/Lq+rXTpcqZIJZe6ALfgMGxy88HmiPvRpWrRw1fUTy85x1U0NnGrqCklZsmWyZUdPwVYj90MQOF2MY/TA==",
       "dependencies": [
@@ -227,6 +647,374 @@
     "@protobufjs/utf8@1.1.0": {
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "@smithy/abort-controller@4.2.5": {
+      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/config-resolver@4.4.3": {
+      "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "@smithy/util-config-provider",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "tslib"
+      ]
+    },
+    "@smithy/core@3.18.5": {
+      "integrity": "sha512-6gnIz3h+PEPQGDj8MnRSjDvKBah042jEoPgjFGJ4iJLBE78L4lY/n98x14XyPF4u3lN179Ub/ZKFY5za9GeLQw==",
+      "dependencies": [
+        "@smithy/middleware-serde",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-middleware",
+        "@smithy/util-stream",
+        "@smithy/util-utf8@4.2.0",
+        "@smithy/uuid",
+        "tslib"
+      ]
+    },
+    "@smithy/credential-provider-imds@4.2.5": {
+      "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/property-provider",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "tslib"
+      ]
+    },
+    "@smithy/fetch-http-handler@5.3.6": {
+      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/querystring-builder",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "tslib"
+      ]
+    },
+    "@smithy/hash-node@4.2.5": {
+      "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+      "dependencies": [
+        "@smithy/types",
+        "@smithy/util-buffer-from@4.2.0",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/invalid-dependency@4.2.5": {
+      "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/is-array-buffer@2.2.0": {
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/is-array-buffer@4.2.0": {
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/md5-js@4.2.5": {
+      "integrity": "sha512-Bt6jpSTMWfjCtC0s79gZ/WZ1w90grfmopVOWqkI2ovhjpD5Q2XRXuecIPB9689L2+cCySMbaXDhBPU56FKNDNg==",
+      "dependencies": [
+        "@smithy/types",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-content-length@4.2.5": {
+      "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-endpoint@4.3.12": {
+      "integrity": "sha512-9pAX/H+VQPzNbouhDhkW723igBMLgrI8OtX+++M7iKJgg/zY/Ig3i1e6seCcx22FWhE6Q/S61BRdi2wXBORT+A==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/middleware-serde",
+        "@smithy/node-config-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-middleware",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-retry@4.4.12": {
+      "integrity": "sha512-S4kWNKFowYd0lID7/DBqWHOQxmxlsf0jBaos9chQZUWTVOjSW1Ogyh8/ib5tM+agFDJ/TCxuCTvrnlc+9cIBcQ==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/protocol-http",
+        "@smithy/service-error-classification",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/uuid",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-serde@4.2.6": {
+      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-stack@4.2.5": {
+      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/node-config-provider@4.3.5": {
+      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "dependencies": [
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/node-http-handler@4.4.5": {
+      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+      "dependencies": [
+        "@smithy/abort-controller",
+        "@smithy/protocol-http",
+        "@smithy/querystring-builder",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/property-provider@4.2.5": {
+      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/protocol-http@5.3.5": {
+      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/querystring-builder@4.2.5": {
+      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+      "dependencies": [
+        "@smithy/types",
+        "@smithy/util-uri-escape",
+        "tslib"
+      ]
+    },
+    "@smithy/querystring-parser@4.2.5": {
+      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/service-error-classification@4.2.5": {
+      "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+      "dependencies": [
+        "@smithy/types"
+      ]
+    },
+    "@smithy/shared-ini-file-loader@4.4.0": {
+      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/signature-v4@5.3.5": {
+      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+      "dependencies": [
+        "@smithy/is-array-buffer@4.2.0",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/util-hex-encoding",
+        "@smithy/util-middleware",
+        "@smithy/util-uri-escape",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/smithy-client@4.9.8": {
+      "integrity": "sha512-8xgq3LgKDEFoIrLWBho/oYKyWByw9/corz7vuh1upv7ZBm0ZMjGYBhbn6v643WoIqA9UTcx5A5htEp/YatUwMA==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-stack",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/util-stream",
+        "tslib"
+      ]
+    },
+    "@smithy/types@4.9.0": {
+      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/url-parser@4.2.5": {
+      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+      "dependencies": [
+        "@smithy/querystring-parser",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-base64@4.3.0": {
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "dependencies": [
+        "@smithy/util-buffer-from@4.2.0",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/util-body-length-browser@4.2.0": {
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-body-length-node@4.2.1": {
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-buffer-from@2.2.0": {
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": [
+        "@smithy/is-array-buffer@2.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/util-buffer-from@4.2.0": {
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "dependencies": [
+        "@smithy/is-array-buffer@4.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/util-config-provider@4.2.0": {
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-defaults-mode-browser@4.3.11": {
+      "integrity": "sha512-yHv+r6wSQXEXTPVCIQTNmXVWs7ekBTpMVErjqZoWkYN75HIFN5y9+/+sYOejfAuvxWGvgzgxbTHa/oz61YTbKw==",
+      "dependencies": [
+        "@smithy/property-provider",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-defaults-mode-node@4.2.14": {
+      "integrity": "sha512-ljZN3iRvaJUgulfvobIuG97q1iUuCMrvXAlkZ4msY+ZuVHQHDIqn7FKZCEj+bx8omz6kF5yQXms/xhzjIO5XiA==",
+      "dependencies": [
+        "@smithy/config-resolver",
+        "@smithy/credential-provider-imds",
+        "@smithy/node-config-provider",
+        "@smithy/property-provider",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-endpoints@3.2.5": {
+      "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-hex-encoding@4.2.0": {
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-middleware@4.2.5": {
+      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-retry@4.2.5": {
+      "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+      "dependencies": [
+        "@smithy/service-error-classification",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-stream@4.5.6": {
+      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+      "dependencies": [
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "@smithy/util-buffer-from@4.2.0",
+        "@smithy/util-hex-encoding",
+        "@smithy/util-utf8@4.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/util-uri-escape@4.2.0": {
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-utf8@2.3.0": {
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": [
+        "@smithy/util-buffer-from@2.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/util-utf8@4.2.0": {
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "dependencies": [
+        "@smithy/util-buffer-from@4.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/uuid@1.1.0": {
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
     "@types/google-protobuf@3.15.12": {
       "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ=="
     },
@@ -279,6 +1067,9 @@
     "aws-ssl-profiles@1.1.2": {
       "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="
     },
+    "bowser@2.13.1": {
+      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw=="
+    },
     "bson@6.10.4": {
       "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="
     },
@@ -319,6 +1110,13 @@
     },
     "escalade@3.2.0": {
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
+    },
+    "fast-xml-parser@5.2.5": {
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dependencies": [
+        "strnum"
+      ],
+      "bin": true
     },
     "generate-function@2.3.1": {
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
@@ -505,11 +1303,17 @@
         "ansi-regex"
       ]
     },
+    "strnum@2.1.1": {
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
+    },
     "tr46@5.1.1": {
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dependencies": [
         "punycode"
       ]
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "undici-types@7.10.0": {
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
@@ -643,6 +1447,12 @@
           "jsr:@db/sqlite@0.12",
           "jsr:@probitas/client-sql@0",
           "jsr:@probitas/client@0"
+        ]
+      },
+      "packages/probitas-client-sqs": {
+        "dependencies": [
+          "jsr:@probitas/client@0",
+          "npm:@aws-sdk/client-sqs@^3.700.0"
         ]
       }
     }

--- a/packages/probitas-client-redis/client.ts
+++ b/packages/probitas-client-redis/client.ts
@@ -102,7 +102,7 @@ async function withOptions<T>(
 export async function createRedisClient(
   config: RedisClientConfig,
 ): Promise<RedisClient> {
-  let redis: RedisInstance;
+  let redis: RedisInstance | undefined;
 
   try {
     if (config.url) {
@@ -123,6 +123,9 @@ export async function createRedisClient(
 
     await redis.connect();
   } catch (error) {
+    if (redis) {
+      redis.disconnect();
+    }
     throw new RedisConnectionError(
       `Failed to connect to Redis: ${
         error instanceof Error ? error.message : String(error)

--- a/packages/probitas-client-sqs/client.ts
+++ b/packages/probitas-client-sqs/client.ts
@@ -1,0 +1,510 @@
+import {
+  DeleteMessageBatchCommand,
+  DeleteMessageCommand,
+  type MessageAttributeValue,
+  PurgeQueueCommand,
+  type QueueAttributeName,
+  ReceiveMessageCommand,
+  SendMessageBatchCommand,
+  SendMessageCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+import { AbortError, TimeoutError } from "@probitas/client";
+import type { CommonOptions } from "@probitas/client";
+import type {
+  SqsBatchMessage,
+  SqsClient,
+  SqsClientConfig,
+  SqsDeleteBatchResult,
+  SqsDeleteResult,
+  SqsMessage,
+  SqsMessageAttribute,
+  SqsReceiveOptions,
+  SqsReceiveResult,
+  SqsSendBatchResult,
+  SqsSendOptions,
+  SqsSendResult,
+} from "./types.ts";
+import {
+  SqsCommandError,
+  SqsConnectionError,
+  SqsMessageNotFoundError,
+  SqsMessageTooLargeError,
+  SqsQueueNotFoundError,
+} from "./errors.ts";
+import { createSqsMessages } from "./messages.ts";
+
+const MAX_MESSAGE_SIZE = 256 * 1024; // 256 KB
+
+/**
+ * Execute a promise with timeout and abort signal support.
+ */
+async function withOptions<T>(
+  promise: Promise<T>,
+  options: CommonOptions | undefined,
+  operation: string,
+): Promise<T> {
+  if (!options?.timeout && !options?.signal) {
+    return promise;
+  }
+
+  const controllers: { cleanup: () => void }[] = [];
+
+  try {
+    const racePromises: Promise<T>[] = [promise];
+
+    if (options.timeout !== undefined) {
+      const timeoutMs = options.timeout;
+      let timeoutId: number;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(
+            new TimeoutError(`Operation timed out: ${operation}`, timeoutMs),
+          );
+        }, timeoutMs);
+      });
+      controllers.push({ cleanup: () => clearTimeout(timeoutId) });
+      racePromises.push(timeoutPromise);
+    }
+
+    if (options.signal) {
+      const signal = options.signal;
+      if (signal.aborted) {
+        throw new AbortError(`Operation aborted: ${operation}`);
+      }
+
+      const abortPromise = new Promise<never>((_, reject) => {
+        const onAbort = () => {
+          reject(new AbortError(`Operation aborted: ${operation}`));
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        controllers.push({
+          cleanup: () => signal.removeEventListener("abort", onAbort),
+        });
+      });
+      racePromises.push(abortPromise);
+    }
+
+    return await Promise.race(racePromises);
+  } finally {
+    for (const controller of controllers) {
+      controller.cleanup();
+    }
+  }
+}
+
+/**
+ * Convert AWS SDK errors to SQS-specific errors.
+ */
+function convertSqsError(
+  error: unknown,
+  operation: string,
+  context?: { queueUrl?: string },
+): never {
+  if (error instanceof TimeoutError || error instanceof AbortError) {
+    throw error;
+  }
+
+  if (error instanceof Error) {
+    const message = error.message;
+    const errorName = error.name;
+
+    if (
+      errorName === "QueueDoesNotExist" ||
+      errorName === "AWS.SimpleQueueService.NonExistentQueue" ||
+      message.includes("does not exist") ||
+      message.includes("NonExistentQueue")
+    ) {
+      throw new SqsQueueNotFoundError(
+        message,
+        context?.queueUrl ?? "unknown",
+        { cause: error },
+      );
+    }
+
+    if (
+      errorName === "ReceiptHandleIsInvalid" ||
+      message.includes("ReceiptHandleIsInvalid") ||
+      message.includes("receipt handle")
+    ) {
+      throw new SqsMessageNotFoundError(message, { cause: error });
+    }
+
+    throw new SqsCommandError(message, {
+      operation,
+      cause: error,
+    });
+  }
+
+  throw new SqsCommandError(String(error), { operation });
+}
+
+/**
+ * Convert SDK message attributes to our format.
+ */
+function convertMessageAttributes(
+  attrs: Record<string, MessageAttributeValue> | undefined,
+): Record<string, SqsMessageAttribute> | undefined {
+  if (!attrs) return undefined;
+
+  const result: Record<string, SqsMessageAttribute> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    result[key] = {
+      dataType: value.DataType as "String" | "Number" | "Binary",
+      stringValue: value.StringValue,
+      binaryValue: value.BinaryValue,
+    };
+  }
+  return result;
+}
+
+/**
+ * Convert our message attributes to SDK format.
+ */
+function toSdkMessageAttributes(
+  attrs: Record<string, SqsMessageAttribute> | undefined,
+): Record<string, MessageAttributeValue> | undefined {
+  if (!attrs) return undefined;
+
+  const result: Record<string, MessageAttributeValue> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    result[key] = {
+      DataType: value.dataType,
+      StringValue: value.stringValue,
+      BinaryValue: value.binaryValue,
+    };
+  }
+  return result;
+}
+
+/**
+ * Validate message size.
+ */
+function validateMessageSize(body: string): void {
+  const size = new TextEncoder().encode(body).length;
+  if (size > MAX_MESSAGE_SIZE) {
+    throw new SqsMessageTooLargeError(
+      `Message size ${size} exceeds maximum allowed size ${MAX_MESSAGE_SIZE}`,
+      size,
+      MAX_MESSAGE_SIZE,
+    );
+  }
+}
+
+/**
+ * Create an SQS client.
+ *
+ * @example
+ * ```typescript
+ * const sqs = await createSqsClient({
+ *   region: "ap-northeast-1",
+ *   queueUrl: "https://sqs.ap-northeast-1.amazonaws.com/123456789/my-queue",
+ *   endpoint: "http://localhost:4566",  // LocalStack
+ * });
+ *
+ * // Send
+ * const sendResult = await sqs.send(JSON.stringify({ type: "ORDER", orderId: "123" }));
+ * expectSqsSendResult(sendResult).ok().hasMessageId();
+ *
+ * // Receive (Long polling)
+ * const receiveResult = await sqs.receive({
+ *   maxMessages: 10,
+ *   waitTimeSeconds: 20,
+ * });
+ * expectSqsReceiveResult(receiveResult).ok().hasContent();
+ *
+ * // Process and delete
+ * for (const msg of receiveResult.messages) {
+ *   console.log(JSON.parse(msg.body));
+ *   await sqs.delete(msg.receiptHandle);
+ * }
+ *
+ * await sqs.close();
+ * ```
+ */
+export function createSqsClient(
+  config: SqsClientConfig,
+): Promise<SqsClient> {
+  let sqsClient: SQSClient;
+
+  try {
+    sqsClient = new SQSClient({
+      endpoint: config.endpoint,
+      region: config.region,
+      credentials: config.credentials,
+    });
+  } catch (error) {
+    throw new SqsConnectionError(
+      `Failed to create SQS client: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error instanceof Error ? error : undefined },
+    );
+  }
+
+  return Promise.resolve(new SqsClientImpl(config, sqsClient));
+}
+
+class SqsClientImpl implements SqsClient {
+  readonly config: SqsClientConfig;
+  readonly #client: SQSClient;
+  #closed = false;
+
+  constructor(config: SqsClientConfig, client: SQSClient) {
+    this.config = config;
+    this.#client = client;
+  }
+
+  async send(
+    body: string,
+    options?: SqsSendOptions,
+  ): Promise<SqsSendResult> {
+    this.#ensureOpen();
+    validateMessageSize(body);
+
+    const startTime = performance.now();
+    const operation = "send";
+
+    try {
+      const command = new SendMessageCommand({
+        QueueUrl: this.config.queueUrl,
+        MessageBody: body,
+        DelaySeconds: options?.delaySeconds,
+        MessageAttributes: toSdkMessageAttributes(options?.messageAttributes),
+        MessageGroupId: options?.messageGroupId,
+        MessageDeduplicationId: options?.messageDeduplicationId,
+      });
+
+      const response = await withOptions(
+        this.#client.send(command),
+        options,
+        operation,
+      );
+
+      return {
+        ok: true,
+        messageId: response.MessageId!,
+        md5OfBody: response.MD5OfMessageBody!,
+        sequenceNumber: response.SequenceNumber,
+        duration: performance.now() - startTime,
+      };
+    } catch (error) {
+      convertSqsError(error, operation, { queueUrl: this.config.queueUrl });
+    }
+  }
+
+  async sendBatch(
+    messages: SqsBatchMessage[],
+  ): Promise<SqsSendBatchResult> {
+    this.#ensureOpen();
+
+    for (const msg of messages) {
+      validateMessageSize(msg.body);
+    }
+
+    const startTime = performance.now();
+    const operation = "sendBatch";
+
+    try {
+      const command = new SendMessageBatchCommand({
+        QueueUrl: this.config.queueUrl,
+        Entries: messages.map((msg) => ({
+          Id: msg.id,
+          MessageBody: msg.body,
+          DelaySeconds: msg.delaySeconds,
+          MessageAttributes: toSdkMessageAttributes(msg.messageAttributes),
+        })),
+      });
+
+      const response = await withOptions(
+        this.#client.send(command),
+        undefined,
+        operation,
+      );
+
+      const successful = (response.Successful ?? []).map((entry) => ({
+        messageId: entry.MessageId!,
+        id: entry.Id!,
+      }));
+
+      const failed = (response.Failed ?? []).map((entry) => ({
+        id: entry.Id!,
+        code: entry.Code!,
+        message: entry.Message ?? "",
+      }));
+
+      return {
+        ok: failed.length === 0,
+        successful,
+        failed,
+        duration: performance.now() - startTime,
+      };
+    } catch (error) {
+      convertSqsError(error, operation, { queueUrl: this.config.queueUrl });
+    }
+  }
+
+  async receive(
+    options?: SqsReceiveOptions,
+  ): Promise<SqsReceiveResult> {
+    this.#ensureOpen();
+    const startTime = performance.now();
+    const operation = "receive";
+
+    try {
+      const command = new ReceiveMessageCommand({
+        QueueUrl: this.config.queueUrl,
+        MaxNumberOfMessages: options?.maxMessages,
+        VisibilityTimeout: options?.visibilityTimeout,
+        WaitTimeSeconds: options?.waitTimeSeconds,
+        MessageAttributeNames: options?.messageAttributeNames as
+          | string[]
+          | undefined,
+        AttributeNames: options?.attributeNames as
+          | QueueAttributeName[]
+          | undefined,
+      });
+
+      const response = await withOptions(
+        this.#client.send(command),
+        options,
+        operation,
+      );
+
+      const messages: SqsMessage[] = (response.Messages ?? []).map((msg) => ({
+        messageId: msg.MessageId!,
+        body: msg.Body!,
+        receiptHandle: msg.ReceiptHandle!,
+        attributes: (msg.Attributes as Record<string, string>) ?? {},
+        messageAttributes: convertMessageAttributes(msg.MessageAttributes),
+        md5OfBody: msg.MD5OfBody!,
+      }));
+
+      return {
+        ok: true,
+        messages: createSqsMessages(messages),
+        duration: performance.now() - startTime,
+      };
+    } catch (error) {
+      convertSqsError(error, operation, { queueUrl: this.config.queueUrl });
+    }
+  }
+
+  async delete(
+    receiptHandle: string,
+    options?: CommonOptions,
+  ): Promise<SqsDeleteResult> {
+    this.#ensureOpen();
+    const startTime = performance.now();
+    const operation = "delete";
+
+    try {
+      const command = new DeleteMessageCommand({
+        QueueUrl: this.config.queueUrl,
+        ReceiptHandle: receiptHandle,
+      });
+
+      await withOptions(
+        this.#client.send(command),
+        options,
+        operation,
+      );
+
+      return {
+        ok: true,
+        duration: performance.now() - startTime,
+      };
+    } catch (error) {
+      convertSqsError(error, operation, { queueUrl: this.config.queueUrl });
+    }
+  }
+
+  async deleteBatch(
+    receiptHandles: string[],
+    options?: CommonOptions,
+  ): Promise<SqsDeleteBatchResult> {
+    this.#ensureOpen();
+    const startTime = performance.now();
+    const operation = "deleteBatch";
+
+    try {
+      const command = new DeleteMessageBatchCommand({
+        QueueUrl: this.config.queueUrl,
+        Entries: receiptHandles.map((handle, index) => ({
+          Id: String(index),
+          ReceiptHandle: handle,
+        })),
+      });
+
+      const response = await withOptions(
+        this.#client.send(command),
+        options,
+        operation,
+      );
+
+      const successful = (response.Successful ?? []).map((entry) => entry.Id!);
+
+      const failed = (response.Failed ?? []).map((entry) => ({
+        id: entry.Id!,
+        code: entry.Code!,
+        message: entry.Message ?? "",
+      }));
+
+      return {
+        ok: failed.length === 0,
+        successful,
+        failed,
+        duration: performance.now() - startTime,
+      };
+    } catch (error) {
+      convertSqsError(error, operation, { queueUrl: this.config.queueUrl });
+    }
+  }
+
+  async purge(options?: CommonOptions): Promise<SqsDeleteResult> {
+    this.#ensureOpen();
+    const startTime = performance.now();
+    const operation = "purge";
+
+    try {
+      const command = new PurgeQueueCommand({
+        QueueUrl: this.config.queueUrl,
+      });
+
+      await withOptions(
+        this.#client.send(command),
+        options,
+        operation,
+      );
+
+      return {
+        ok: true,
+        duration: performance.now() - startTime,
+      };
+    } catch (error) {
+      convertSqsError(error, operation, { queueUrl: this.config.queueUrl });
+    }
+  }
+
+  close(): Promise<void> {
+    if (this.#closed) return Promise.resolve();
+    this.#closed = true;
+
+    try {
+      this.#client.destroy();
+    } catch {
+      // Ignore close errors
+    }
+    return Promise.resolve();
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close();
+  }
+
+  #ensureOpen(): void {
+    if (this.#closed) {
+      throw new SqsCommandError("Client is closed", { operation: "" });
+    }
+  }
+}

--- a/packages/probitas-client-sqs/deno.json
+++ b/packages/probitas-client-sqs/deno.json
@@ -1,0 +1,12 @@
+{
+  "name": "@probitas/client-sqs",
+  "version": "0.0.0",
+  "exports": "./mod.ts",
+  "publish": {
+    "exclude": ["**/*_test.ts", "**/*_bench.ts"]
+  },
+  "imports": {
+    "@probitas/client": "jsr:@probitas/client@^0",
+    "@aws-sdk/client-sqs": "npm:@aws-sdk/client-sqs@^3.700.0"
+  }
+}

--- a/packages/probitas-client-sqs/errors.ts
+++ b/packages/probitas-client-sqs/errors.ts
@@ -1,0 +1,119 @@
+import { ClientError } from "@probitas/client";
+
+/**
+ * Options for SQS errors.
+ */
+export interface SqsErrorOptions extends ErrorOptions {
+  readonly code?: string;
+}
+
+/**
+ * Base error class for SQS client errors.
+ */
+export class SqsError extends ClientError {
+  override readonly name: string = "SqsError";
+  readonly code?: string;
+
+  constructor(
+    message: string,
+    kind: string = "sqs",
+    options?: SqsErrorOptions,
+  ) {
+    super(message, kind, options);
+    this.code = options?.code;
+  }
+}
+
+/**
+ * Error thrown when an SQS connection cannot be established.
+ */
+export class SqsConnectionError extends SqsError {
+  override readonly name = "SqsConnectionError";
+  override readonly kind = "connection" as const;
+
+  constructor(message: string, options?: SqsErrorOptions) {
+    super(message, "connection", options);
+  }
+}
+
+/**
+ * Options for SQS command errors.
+ */
+export interface SqsCommandErrorOptions extends SqsErrorOptions {
+  readonly operation: string;
+}
+
+/**
+ * Error thrown when an SQS command fails.
+ */
+export class SqsCommandError extends SqsError {
+  override readonly name = "SqsCommandError";
+  override readonly kind = "command" as const;
+  readonly operation: string;
+
+  constructor(message: string, options: SqsCommandErrorOptions) {
+    super(message, "command", options);
+    this.operation = options.operation;
+  }
+}
+
+/**
+ * Error thrown when a queue is not found.
+ */
+export class SqsQueueNotFoundError extends SqsError {
+  override readonly name = "SqsQueueNotFoundError";
+  override readonly kind = "queue_not_found" as const;
+  readonly queueUrl: string;
+
+  constructor(message: string, queueUrl: string, options?: SqsErrorOptions) {
+    super(message, "queue_not_found", options);
+    this.queueUrl = queueUrl;
+  }
+}
+
+/**
+ * Error thrown when a message exceeds the size limit.
+ */
+export class SqsMessageTooLargeError extends SqsError {
+  override readonly name = "SqsMessageTooLargeError";
+  override readonly kind = "message_too_large" as const;
+  readonly size: number;
+  readonly maxSize: number;
+
+  constructor(
+    message: string,
+    size: number,
+    maxSize: number,
+    options?: SqsErrorOptions,
+  ) {
+    super(message, "message_too_large", options);
+    this.size = size;
+    this.maxSize = maxSize;
+  }
+}
+
+/**
+ * Error thrown when a batch operation partially fails.
+ */
+export class SqsBatchError extends SqsError {
+  override readonly name = "SqsBatchError";
+  override readonly kind = "batch" as const;
+  readonly failedCount: number;
+
+  constructor(message: string, failedCount: number, options?: SqsErrorOptions) {
+    super(message, "batch", options);
+    this.failedCount = failedCount;
+  }
+}
+
+/**
+ * Error thrown when a message is not found or receipt handle is invalid.
+ */
+export class SqsMessageNotFoundError extends SqsError {
+  override readonly name = "SqsMessageNotFoundError";
+  override readonly kind = "message_not_found" as const;
+
+  constructor(message: string, options?: SqsErrorOptions) {
+    super(message, "message_not_found", options);
+  }
+}

--- a/packages/probitas-client-sqs/errors_test.ts
+++ b/packages/probitas-client-sqs/errors_test.ts
@@ -1,0 +1,138 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { ClientError } from "@probitas/client";
+import {
+  SqsBatchError,
+  SqsCommandError,
+  SqsConnectionError,
+  SqsError,
+  SqsMessageNotFoundError,
+  SqsMessageTooLargeError,
+  SqsQueueNotFoundError,
+} from "./errors.ts";
+
+Deno.test("SqsError", async (t) => {
+  await t.step("extends ClientError", () => {
+    const error = new SqsError("test message");
+    assertInstanceOf(error, ClientError);
+    assertInstanceOf(error, Error);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new SqsError("test message", "test-kind", {
+      code: "TEST001",
+    });
+    assertEquals(error.name, "SqsError");
+    assertEquals(error.message, "test message");
+    assertEquals(error.kind, "test-kind");
+    assertEquals(error.code, "TEST001");
+  });
+
+  await t.step("supports error cause", () => {
+    const cause = new Error("original error");
+    const error = new SqsError("wrapped", "sqs", { cause });
+    assertEquals(error.cause, cause);
+  });
+});
+
+Deno.test("SqsConnectionError", async (t) => {
+  await t.step("extends SqsError", () => {
+    const error = new SqsConnectionError("connection failed");
+    assertInstanceOf(error, SqsError);
+    assertInstanceOf(error, ClientError);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new SqsConnectionError("connection failed");
+    assertEquals(error.name, "SqsConnectionError");
+    assertEquals(error.kind, "connection");
+    assertEquals(error.message, "connection failed");
+  });
+});
+
+Deno.test("SqsCommandError", async (t) => {
+  await t.step("extends SqsError", () => {
+    const error = new SqsCommandError("command failed", {
+      operation: "send",
+    });
+    assertInstanceOf(error, SqsError);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new SqsCommandError("command failed", {
+      operation: "send",
+      code: "ERR001",
+    });
+    assertEquals(error.name, "SqsCommandError");
+    assertEquals(error.kind, "command");
+    assertEquals(error.operation, "send");
+    assertEquals(error.code, "ERR001");
+  });
+});
+
+Deno.test("SqsQueueNotFoundError", async (t) => {
+  await t.step("extends SqsError", () => {
+    const error = new SqsQueueNotFoundError(
+      "queue not found",
+      "https://sqs.us-east-1.amazonaws.com/123/my-queue",
+    );
+    assertInstanceOf(error, SqsError);
+  });
+
+  await t.step("has correct properties", () => {
+    const queueUrl = "https://sqs.us-east-1.amazonaws.com/123/my-queue";
+    const error = new SqsQueueNotFoundError("queue not found", queueUrl);
+    assertEquals(error.name, "SqsQueueNotFoundError");
+    assertEquals(error.kind, "queue_not_found");
+    assertEquals(error.queueUrl, queueUrl);
+  });
+});
+
+Deno.test("SqsMessageNotFoundError", async (t) => {
+  await t.step("extends SqsError", () => {
+    const error = new SqsMessageNotFoundError("message not found");
+    assertInstanceOf(error, SqsError);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new SqsMessageNotFoundError("message not found");
+    assertEquals(error.name, "SqsMessageNotFoundError");
+    assertEquals(error.kind, "message_not_found");
+  });
+});
+
+Deno.test("SqsMessageTooLargeError", async (t) => {
+  await t.step("extends SqsError", () => {
+    const error = new SqsMessageTooLargeError(
+      "message too large",
+      300000,
+      262144,
+    );
+    assertInstanceOf(error, SqsError);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new SqsMessageTooLargeError(
+      "message too large",
+      300000,
+      262144,
+    );
+    assertEquals(error.name, "SqsMessageTooLargeError");
+    assertEquals(error.kind, "message_too_large");
+    assertEquals(error.size, 300000);
+    assertEquals(error.maxSize, 262144);
+  });
+});
+
+Deno.test("SqsBatchError", async (t) => {
+  await t.step("extends SqsError", () => {
+    const error = new SqsBatchError("batch operation failed", 3);
+    assertInstanceOf(error, SqsError);
+  });
+
+  await t.step("has correct properties", () => {
+    const error = new SqsBatchError("batch operation failed", 3);
+    assertEquals(error.name, "SqsBatchError");
+    assertEquals(error.kind, "batch");
+    assertEquals(error.failedCount, 3);
+  });
+});

--- a/packages/probitas-client-sqs/expect.ts
+++ b/packages/probitas-client-sqs/expect.ts
@@ -1,0 +1,639 @@
+import type {
+  SqsDeleteBatchResult,
+  SqsDeleteResult,
+  SqsMessage,
+  SqsMessageAttribute,
+  SqsMessages,
+  SqsReceiveResult,
+  SqsSendBatchResult,
+  SqsSendResult,
+} from "./types.ts";
+
+/**
+ * Check if subset properties exist in target object.
+ */
+function containsSubset(
+  target: Record<string, unknown>,
+  subset: Record<string, unknown>,
+): boolean {
+  for (const key of Object.keys(subset)) {
+    if (!(key in target)) return false;
+    const targetValue = target[key];
+    const subsetValue = subset[key];
+
+    if (
+      typeof subsetValue === "object" && subsetValue !== null &&
+      typeof targetValue === "object" && targetValue !== null
+    ) {
+      if (
+        !containsSubset(
+          targetValue as Record<string, unknown>,
+          subsetValue as Record<string, unknown>,
+        )
+      ) {
+        return false;
+      }
+    } else if (targetValue !== subsetValue) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Fluent API for SQS send result validation.
+ */
+export interface SqsSendResultExpectation {
+  /** Assert that result ok is true */
+  ok(): this;
+
+  /** Assert that result ok is false */
+  notOk(): this;
+
+  /** Assert that messageId exists */
+  hasMessageId(): this;
+
+  /** Assert that duration is less than threshold (ms) */
+  durationLessThan(ms: number): this;
+}
+
+/**
+ * Fluent API for SQS send batch result validation.
+ */
+export interface SqsSendBatchResultExpectation {
+  /** Assert that result ok is true */
+  ok(): this;
+
+  /** Assert that result ok is false */
+  notOk(): this;
+
+  /** Assert that all messages were sent successfully */
+  allSuccessful(): this;
+
+  /** Assert that successful count matches expected */
+  successfulCount(count: number): this;
+
+  /** Assert that failed count matches expected */
+  failedCount(count: number): this;
+
+  /** Assert that there are no failures */
+  noFailures(): this;
+
+  /** Assert that duration is less than threshold (ms) */
+  durationLessThan(ms: number): this;
+}
+
+/**
+ * Fluent API for SQS receive result validation.
+ */
+export interface SqsReceiveResultExpectation {
+  /** Assert that result ok is true */
+  ok(): this;
+
+  /** Assert that result ok is false */
+  notOk(): this;
+
+  /** Assert that messages array is empty */
+  noContent(): this;
+
+  /** Assert that messages array has at least one message */
+  hasContent(): this;
+
+  /** Assert that messages array has exactly count messages */
+  count(expected: number): this;
+
+  /** Assert that messages array has at least min messages */
+  countAtLeast(min: number): this;
+
+  /** Assert that messages array has at most max messages */
+  countAtMost(max: number): this;
+
+  /** Assert that at least one message contains the given subset */
+  messageContains(
+    subset: { body?: string; attributes?: Record<string, string> },
+  ): this;
+
+  /** Assert messages using custom matcher function */
+  messagesMatch(matcher: (messages: SqsMessages) => void): this;
+
+  /** Assert that duration is less than threshold (ms) */
+  durationLessThan(ms: number): this;
+}
+
+/**
+ * Fluent API for SQS delete result validation.
+ */
+export interface SqsDeleteResultExpectation {
+  /** Assert that result ok is true */
+  ok(): this;
+
+  /** Assert that result ok is false */
+  notOk(): this;
+
+  /** Assert that duration is less than threshold (ms) */
+  durationLessThan(ms: number): this;
+}
+
+/**
+ * Fluent API for SQS message validation.
+ */
+export interface SqsMessageExpectation {
+  /** Assert that body contains the given substring */
+  bodyContains(substring: string): this;
+
+  /** Assert body using custom matcher function */
+  bodyMatch(matcher: (body: string) => void): this;
+
+  /** Assert that body equals expected JSON (deep equality) */
+  // deno-lint-ignore no-explicit-any
+  bodyJsonEquals<T = any>(expected: T): this;
+
+  /** Assert that body JSON contains the given subset */
+  // deno-lint-ignore no-explicit-any
+  bodyJsonContains<T = any>(subset: Partial<T>): this;
+
+  /** Assert that message has the given attribute */
+  hasAttribute(name: string): this;
+
+  /** Assert that message attributes contain the given subset */
+  attributesContain(subset: Record<string, Partial<SqsMessageAttribute>>): this;
+
+  /** Assert that messageId matches expected */
+  messageId(expected: string): this;
+}
+
+/**
+ * Implementation for SQS send result expectations.
+ */
+class SqsSendResultExpectationImpl implements SqsSendResultExpectation {
+  readonly #result: SqsSendResult;
+
+  constructor(result: SqsSendResult) {
+    this.#result = result;
+  }
+
+  ok(): this {
+    if (!this.#result.ok) {
+      throw new Error("Expected ok result, but ok is false");
+    }
+    return this;
+  }
+
+  notOk(): this {
+    if (this.#result.ok) {
+      throw new Error("Expected not ok result, but ok is true");
+    }
+    return this;
+  }
+
+  hasMessageId(): this {
+    if (!this.#result.messageId) {
+      throw new Error("Expected messageId, but messageId is undefined");
+    }
+    return this;
+  }
+
+  durationLessThan(ms: number): this {
+    if (this.#result.duration >= ms) {
+      throw new Error(
+        `Expected duration < ${ms}ms, got ${this.#result.duration}ms`,
+      );
+    }
+    return this;
+  }
+}
+
+/**
+ * Implementation for SQS send batch result expectations.
+ */
+class SqsSendBatchResultExpectationImpl
+  implements SqsSendBatchResultExpectation {
+  readonly #result: SqsSendBatchResult;
+
+  constructor(result: SqsSendBatchResult) {
+    this.#result = result;
+  }
+
+  ok(): this {
+    if (!this.#result.ok) {
+      throw new Error("Expected ok result, but ok is false");
+    }
+    return this;
+  }
+
+  notOk(): this {
+    if (this.#result.ok) {
+      throw new Error("Expected not ok result, but ok is true");
+    }
+    return this;
+  }
+
+  allSuccessful(): this {
+    if (this.#result.failed.length > 0) {
+      throw new Error(
+        `Expected all messages successful, but ${this.#result.failed.length} failed`,
+      );
+    }
+    return this;
+  }
+
+  successfulCount(count: number): this {
+    if (this.#result.successful.length !== count) {
+      throw new Error(
+        `Expected ${count} successful, got ${this.#result.successful.length}`,
+      );
+    }
+    return this;
+  }
+
+  failedCount(count: number): this {
+    if (this.#result.failed.length !== count) {
+      throw new Error(
+        `Expected ${count} failed, got ${this.#result.failed.length}`,
+      );
+    }
+    return this;
+  }
+
+  noFailures(): this {
+    if (this.#result.failed.length > 0) {
+      throw new Error(
+        `Expected no failures, but ${this.#result.failed.length} failed`,
+      );
+    }
+    return this;
+  }
+
+  durationLessThan(ms: number): this {
+    if (this.#result.duration >= ms) {
+      throw new Error(
+        `Expected duration < ${ms}ms, got ${this.#result.duration}ms`,
+      );
+    }
+    return this;
+  }
+}
+
+/**
+ * Implementation for SQS receive result expectations.
+ */
+class SqsReceiveResultExpectationImpl implements SqsReceiveResultExpectation {
+  readonly #result: SqsReceiveResult;
+
+  constructor(result: SqsReceiveResult) {
+    this.#result = result;
+  }
+
+  ok(): this {
+    if (!this.#result.ok) {
+      throw new Error("Expected ok result, but ok is false");
+    }
+    return this;
+  }
+
+  notOk(): this {
+    if (this.#result.ok) {
+      throw new Error("Expected not ok result, but ok is true");
+    }
+    return this;
+  }
+
+  noContent(): this {
+    if (this.#result.messages.length !== 0) {
+      throw new Error(
+        `Expected no messages, but got ${this.#result.messages.length} messages`,
+      );
+    }
+    return this;
+  }
+
+  hasContent(): this {
+    if (this.#result.messages.length === 0) {
+      throw new Error("Expected messages, but messages array is empty");
+    }
+    return this;
+  }
+
+  count(expected: number): this {
+    if (this.#result.messages.length !== expected) {
+      throw new Error(
+        `Expected ${expected} messages, got ${this.#result.messages.length}`,
+      );
+    }
+    return this;
+  }
+
+  countAtLeast(min: number): this {
+    if (this.#result.messages.length < min) {
+      throw new Error(
+        `Expected at least ${min} messages, got ${this.#result.messages.length}`,
+      );
+    }
+    return this;
+  }
+
+  countAtMost(max: number): this {
+    if (this.#result.messages.length > max) {
+      throw new Error(
+        `Expected at most ${max} messages, got ${this.#result.messages.length}`,
+      );
+    }
+    return this;
+  }
+
+  messageContains(
+    subset: { body?: string; attributes?: Record<string, string> },
+  ): this {
+    const found = this.#result.messages.some((msg) => {
+      if (subset.body !== undefined && !msg.body.includes(subset.body)) {
+        return false;
+      }
+      if (subset.attributes !== undefined) {
+        for (const [key, value] of Object.entries(subset.attributes)) {
+          if (msg.attributes[key] !== value) {
+            return false;
+          }
+        }
+      }
+      return true;
+    });
+
+    if (!found) {
+      throw new Error(
+        `Expected at least one message to contain ${JSON.stringify(subset)}`,
+      );
+    }
+    return this;
+  }
+
+  messagesMatch(matcher: (messages: SqsMessages) => void): this {
+    matcher(this.#result.messages);
+    return this;
+  }
+
+  durationLessThan(ms: number): this {
+    if (this.#result.duration >= ms) {
+      throw new Error(
+        `Expected duration < ${ms}ms, got ${this.#result.duration}ms`,
+      );
+    }
+    return this;
+  }
+}
+
+/**
+ * Implementation for SQS delete result expectations.
+ */
+class SqsDeleteResultExpectationImpl implements SqsDeleteResultExpectation {
+  readonly #result: SqsDeleteResult;
+
+  constructor(result: SqsDeleteResult) {
+    this.#result = result;
+  }
+
+  ok(): this {
+    if (!this.#result.ok) {
+      throw new Error("Expected ok result, but ok is false");
+    }
+    return this;
+  }
+
+  notOk(): this {
+    if (this.#result.ok) {
+      throw new Error("Expected not ok result, but ok is true");
+    }
+    return this;
+  }
+
+  durationLessThan(ms: number): this {
+    if (this.#result.duration >= ms) {
+      throw new Error(
+        `Expected duration < ${ms}ms, got ${this.#result.duration}ms`,
+      );
+    }
+    return this;
+  }
+}
+
+/**
+ * Implementation for SQS delete batch result expectations.
+ * Reuses the same interface as SqsSendBatchResultExpectation per spec.
+ */
+class SqsDeleteBatchResultExpectationImpl
+  implements SqsSendBatchResultExpectation {
+  readonly #result: SqsDeleteBatchResult;
+
+  constructor(result: SqsDeleteBatchResult) {
+    this.#result = result;
+  }
+
+  ok(): this {
+    if (!this.#result.ok) {
+      throw new Error("Expected ok result, but ok is false");
+    }
+    return this;
+  }
+
+  notOk(): this {
+    if (this.#result.ok) {
+      throw new Error("Expected not ok result, but ok is true");
+    }
+    return this;
+  }
+
+  allSuccessful(): this {
+    if (this.#result.failed.length > 0) {
+      throw new Error(
+        `Expected all deletions successful, but ${this.#result.failed.length} failed`,
+      );
+    }
+    return this;
+  }
+
+  successfulCount(count: number): this {
+    if (this.#result.successful.length !== count) {
+      throw new Error(
+        `Expected ${count} successful, got ${this.#result.successful.length}`,
+      );
+    }
+    return this;
+  }
+
+  failedCount(count: number): this {
+    if (this.#result.failed.length !== count) {
+      throw new Error(
+        `Expected ${count} failed, got ${this.#result.failed.length}`,
+      );
+    }
+    return this;
+  }
+
+  noFailures(): this {
+    if (this.#result.failed.length > 0) {
+      throw new Error(
+        `Expected no failures, but ${this.#result.failed.length} failed`,
+      );
+    }
+    return this;
+  }
+
+  durationLessThan(ms: number): this {
+    if (this.#result.duration >= ms) {
+      throw new Error(
+        `Expected duration < ${ms}ms, got ${this.#result.duration}ms`,
+      );
+    }
+    return this;
+  }
+}
+
+/**
+ * Implementation for SQS message expectations.
+ */
+class SqsMessageExpectationImpl implements SqsMessageExpectation {
+  readonly #message: SqsMessage;
+
+  constructor(message: SqsMessage) {
+    this.#message = message;
+  }
+
+  bodyContains(substring: string): this {
+    if (!this.#message.body.includes(substring)) {
+      throw new Error(
+        `Expected body to contain "${substring}", but got "${this.#message.body}"`,
+      );
+    }
+    return this;
+  }
+
+  bodyMatch(matcher: (body: string) => void): this {
+    matcher(this.#message.body);
+    return this;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  bodyJsonEquals<T = any>(expected: T): this {
+    const actual = JSON.parse(this.#message.body);
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(
+        `Expected body JSON to equal ${JSON.stringify(expected)}, got ${
+          JSON.stringify(actual)
+        }`,
+      );
+    }
+    return this;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  bodyJsonContains<T = any>(subset: Partial<T>): this {
+    const actual = JSON.parse(this.#message.body);
+    if (
+      !containsSubset(
+        actual as Record<string, unknown>,
+        subset as Record<string, unknown>,
+      )
+    ) {
+      throw new Error(
+        `Expected body JSON to contain ${JSON.stringify(subset)}, got ${
+          JSON.stringify(actual)
+        }`,
+      );
+    }
+    return this;
+  }
+
+  hasAttribute(name: string): this {
+    if (!this.#message.messageAttributes?.[name]) {
+      throw new Error(`Expected message to have attribute "${name}"`);
+    }
+    return this;
+  }
+
+  attributesContain(
+    subset: Record<string, Partial<SqsMessageAttribute>>,
+  ): this {
+    const attrs = this.#message.messageAttributes ?? {};
+    for (const [key, expected] of Object.entries(subset)) {
+      const actual = attrs[key];
+      if (!actual) {
+        throw new Error(`Expected attribute "${key}" to exist`);
+      }
+      if (
+        !containsSubset(
+          actual as unknown as Record<string, unknown>,
+          expected as unknown as Record<string, unknown>,
+        )
+      ) {
+        throw new Error(
+          `Expected attribute "${key}" to contain ${
+            JSON.stringify(expected)
+          }, got ${JSON.stringify(actual)}`,
+        );
+      }
+    }
+    return this;
+  }
+
+  messageId(expected: string): this {
+    if (this.#message.messageId !== expected) {
+      throw new Error(
+        `Expected messageId "${expected}", got "${this.#message.messageId}"`,
+      );
+    }
+    return this;
+  }
+}
+
+/**
+ * Create a fluent expectation chain for SQS send result validation.
+ */
+export function expectSqsSendResult(
+  result: SqsSendResult,
+): SqsSendResultExpectation {
+  return new SqsSendResultExpectationImpl(result);
+}
+
+/**
+ * Create a fluent expectation chain for SQS send batch result validation.
+ */
+export function expectSqsSendBatchResult(
+  result: SqsSendBatchResult,
+): SqsSendBatchResultExpectation {
+  return new SqsSendBatchResultExpectationImpl(result);
+}
+
+/**
+ * Create a fluent expectation chain for SQS receive result validation.
+ */
+export function expectSqsReceiveResult(
+  result: SqsReceiveResult,
+): SqsReceiveResultExpectation {
+  return new SqsReceiveResultExpectationImpl(result);
+}
+
+/**
+ * Create a fluent expectation chain for SQS delete result validation.
+ */
+export function expectSqsDeleteResult(
+  result: SqsDeleteResult,
+): SqsDeleteResultExpectation {
+  return new SqsDeleteResultExpectationImpl(result);
+}
+
+/**
+ * Create a fluent expectation chain for SQS delete batch result validation.
+ */
+export function expectSqsDeleteBatchResult(
+  result: SqsDeleteBatchResult,
+): SqsSendBatchResultExpectation {
+  return new SqsDeleteBatchResultExpectationImpl(result);
+}
+
+/**
+ * Create a fluent expectation chain for SQS message validation.
+ */
+export function expectSqsMessage(
+  message: SqsMessage,
+): SqsMessageExpectation {
+  return new SqsMessageExpectationImpl(message);
+}

--- a/packages/probitas-client-sqs/expect_test.ts
+++ b/packages/probitas-client-sqs/expect_test.ts
@@ -1,0 +1,502 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import type {
+  SqsDeleteBatchResult,
+  SqsDeleteResult,
+  SqsMessage,
+  SqsReceiveResult,
+  SqsSendBatchResult,
+  SqsSendResult,
+} from "./types.ts";
+import { createSqsMessages } from "./messages.ts";
+import {
+  expectSqsDeleteBatchResult,
+  expectSqsDeleteResult,
+  expectSqsMessage,
+  expectSqsReceiveResult,
+  expectSqsSendBatchResult,
+  expectSqsSendResult,
+} from "./expect.ts";
+
+Deno.test("expectSqsSendResult", async (t) => {
+  const successResult: SqsSendResult = {
+    ok: true,
+    messageId: "msg-123",
+    md5OfBody: "abc123",
+    duration: 50,
+  };
+
+  const failedResult: SqsSendResult = {
+    ok: false,
+    messageId: "",
+    md5OfBody: "",
+    duration: 100,
+  };
+
+  await t.step("ok() passes for successful result", () => {
+    expectSqsSendResult(successResult).ok();
+  });
+
+  await t.step("ok() throws for failed result", () => {
+    assertThrows(
+      () => expectSqsSendResult(failedResult).ok(),
+      Error,
+      "Expected ok result",
+    );
+  });
+
+  await t.step("notOk() passes for failed result", () => {
+    expectSqsSendResult(failedResult).notOk();
+  });
+
+  await t.step("notOk() throws for successful result", () => {
+    assertThrows(
+      () => expectSqsSendResult(successResult).notOk(),
+      Error,
+      "Expected not ok result",
+    );
+  });
+
+  await t.step("hasMessageId() passes when messageId exists", () => {
+    expectSqsSendResult(successResult).hasMessageId();
+  });
+
+  await t.step("hasMessageId() throws when messageId is empty", () => {
+    assertThrows(
+      () => expectSqsSendResult(failedResult).hasMessageId(),
+      Error,
+      "Expected messageId",
+    );
+  });
+
+  await t.step("durationLessThan() passes when duration is less", () => {
+    expectSqsSendResult(successResult).durationLessThan(100);
+  });
+
+  await t.step("durationLessThan() throws when duration is greater", () => {
+    assertThrows(
+      () => expectSqsSendResult(successResult).durationLessThan(30),
+      Error,
+      "Expected duration",
+    );
+  });
+
+  await t.step("chaining works", () => {
+    expectSqsSendResult(successResult)
+      .ok()
+      .hasMessageId()
+      .durationLessThan(100);
+  });
+});
+
+Deno.test("expectSqsSendBatchResult", async (t) => {
+  const allSuccess: SqsSendBatchResult = {
+    ok: true,
+    successful: [
+      { messageId: "msg-1", id: "0" },
+      { messageId: "msg-2", id: "1" },
+    ],
+    failed: [],
+    duration: 50,
+  };
+
+  const partialFailure: SqsSendBatchResult = {
+    ok: false,
+    successful: [{ messageId: "msg-1", id: "0" }],
+    failed: [{ id: "1", code: "InvalidParameterValue", message: "Invalid" }],
+    duration: 60,
+  };
+
+  await t.step("ok() passes for all successful", () => {
+    expectSqsSendBatchResult(allSuccess).ok();
+  });
+
+  await t.step("notOk() passes for partial failure", () => {
+    expectSqsSendBatchResult(partialFailure).notOk();
+  });
+
+  await t.step("allSuccessful() passes when no failures", () => {
+    expectSqsSendBatchResult(allSuccess).allSuccessful();
+  });
+
+  await t.step("allSuccessful() throws when there are failures", () => {
+    assertThrows(
+      () => expectSqsSendBatchResult(partialFailure).allSuccessful(),
+      Error,
+      "Expected all messages successful",
+    );
+  });
+
+  await t.step("successfulCount() passes with correct count", () => {
+    expectSqsSendBatchResult(allSuccess).successfulCount(2);
+  });
+
+  await t.step("successfulCount() throws with wrong count", () => {
+    assertThrows(
+      () => expectSqsSendBatchResult(allSuccess).successfulCount(3),
+      Error,
+      "Expected 3 successful",
+    );
+  });
+
+  await t.step("failedCount() passes with correct count", () => {
+    expectSqsSendBatchResult(partialFailure).failedCount(1);
+  });
+
+  await t.step("noFailures() passes when no failures", () => {
+    expectSqsSendBatchResult(allSuccess).noFailures();
+  });
+
+  await t.step("noFailures() throws when there are failures", () => {
+    assertThrows(
+      () => expectSqsSendBatchResult(partialFailure).noFailures(),
+      Error,
+      "Expected no failures",
+    );
+  });
+
+  await t.step("chaining works", () => {
+    expectSqsSendBatchResult(allSuccess)
+      .ok()
+      .allSuccessful()
+      .successfulCount(2)
+      .noFailures();
+  });
+});
+
+Deno.test("expectSqsReceiveResult", async (t) => {
+  const messages: SqsMessage[] = [
+    {
+      messageId: "1",
+      receiptHandle: "r1",
+      body: "body1",
+      attributes: { SenderId: "123" },
+      md5OfBody: "abc",
+    },
+    {
+      messageId: "2",
+      receiptHandle: "r2",
+      body: "body2",
+      attributes: {},
+      md5OfBody: "def",
+    },
+  ];
+
+  const withMessages: SqsReceiveResult = {
+    ok: true,
+    messages: createSqsMessages(messages),
+    duration: 50,
+  };
+
+  const emptyResult: SqsReceiveResult = {
+    ok: true,
+    messages: createSqsMessages([]),
+    duration: 30,
+  };
+
+  await t.step("ok() passes for successful result", () => {
+    expectSqsReceiveResult(withMessages).ok();
+  });
+
+  await t.step("noContent() passes for empty messages", () => {
+    expectSqsReceiveResult(emptyResult).noContent();
+  });
+
+  await t.step("noContent() throws when messages exist", () => {
+    assertThrows(
+      () => expectSqsReceiveResult(withMessages).noContent(),
+      Error,
+      "Expected no messages",
+    );
+  });
+
+  await t.step("hasContent() passes when messages exist", () => {
+    expectSqsReceiveResult(withMessages).hasContent();
+  });
+
+  await t.step("hasContent() throws when no messages", () => {
+    assertThrows(
+      () => expectSqsReceiveResult(emptyResult).hasContent(),
+      Error,
+      "Expected messages",
+    );
+  });
+
+  await t.step("count() passes with correct count", () => {
+    expectSqsReceiveResult(withMessages).count(2);
+  });
+
+  await t.step("count() throws with wrong count", () => {
+    assertThrows(
+      () => expectSqsReceiveResult(withMessages).count(3),
+      Error,
+      "Expected 3 messages",
+    );
+  });
+
+  await t.step("countAtLeast() passes when count is sufficient", () => {
+    expectSqsReceiveResult(withMessages).countAtLeast(1);
+  });
+
+  await t.step("countAtLeast() throws when count is insufficient", () => {
+    assertThrows(
+      () => expectSqsReceiveResult(withMessages).countAtLeast(5),
+      Error,
+      "Expected at least 5 messages",
+    );
+  });
+
+  await t.step("countAtMost() passes when count is within limit", () => {
+    expectSqsReceiveResult(withMessages).countAtMost(5);
+  });
+
+  await t.step("countAtMost() throws when count exceeds limit", () => {
+    assertThrows(
+      () => expectSqsReceiveResult(withMessages).countAtMost(1),
+      Error,
+      "Expected at most 1 messages",
+    );
+  });
+
+  await t.step("messageContains() passes when body matches", () => {
+    expectSqsReceiveResult(withMessages).messageContains({ body: "body1" });
+  });
+
+  await t.step("messageContains() passes when attributes match", () => {
+    expectSqsReceiveResult(withMessages).messageContains({
+      attributes: { SenderId: "123" },
+    });
+  });
+
+  await t.step("messageContains() throws when no message matches", () => {
+    assertThrows(
+      () =>
+        expectSqsReceiveResult(withMessages).messageContains({
+          body: "notfound",
+        }),
+      Error,
+      "Expected at least one message to contain",
+    );
+  });
+
+  await t.step("messagesMatch() calls matcher with messages", () => {
+    let called = false;
+    expectSqsReceiveResult(withMessages).messagesMatch((msgs) => {
+      called = true;
+      assertEquals(msgs.length, 2);
+      assertEquals(msgs.first()?.body, "body1");
+    });
+    assertEquals(called, true);
+  });
+
+  await t.step("chaining works", () => {
+    expectSqsReceiveResult(withMessages)
+      .ok()
+      .hasContent()
+      .count(2)
+      .countAtLeast(1)
+      .countAtMost(5);
+  });
+});
+
+Deno.test("expectSqsDeleteResult", async (t) => {
+  const successResult: SqsDeleteResult = {
+    ok: true,
+    duration: 30,
+  };
+
+  const failedResult: SqsDeleteResult = {
+    ok: false,
+    duration: 50,
+  };
+
+  await t.step("ok() passes for successful result", () => {
+    expectSqsDeleteResult(successResult).ok();
+  });
+
+  await t.step("notOk() passes for failed result", () => {
+    expectSqsDeleteResult(failedResult).notOk();
+  });
+
+  await t.step("durationLessThan() passes when duration is less", () => {
+    expectSqsDeleteResult(successResult).durationLessThan(50);
+  });
+
+  await t.step("durationLessThan() throws when duration is greater", () => {
+    assertThrows(
+      () => expectSqsDeleteResult(successResult).durationLessThan(20),
+      Error,
+      "Expected duration",
+    );
+  });
+});
+
+Deno.test("expectSqsDeleteBatchResult", async (t) => {
+  const allSuccess: SqsDeleteBatchResult = {
+    ok: true,
+    successful: ["0", "1", "2"],
+    failed: [],
+    duration: 40,
+  };
+
+  const partialFailure: SqsDeleteBatchResult = {
+    ok: false,
+    successful: ["0"],
+    failed: [{ id: "1", code: "ReceiptHandleIsInvalid", message: "Invalid" }],
+    duration: 50,
+  };
+
+  await t.step("ok() passes for all successful", () => {
+    expectSqsDeleteBatchResult(allSuccess).ok();
+  });
+
+  await t.step("notOk() passes for partial failure", () => {
+    expectSqsDeleteBatchResult(partialFailure).notOk();
+  });
+
+  await t.step("allSuccessful() passes when no failures", () => {
+    expectSqsDeleteBatchResult(allSuccess).allSuccessful();
+  });
+
+  await t.step("allSuccessful() throws when there are failures", () => {
+    assertThrows(
+      () => expectSqsDeleteBatchResult(partialFailure).allSuccessful(),
+      Error,
+      "Expected all deletions successful",
+    );
+  });
+
+  await t.step("successfulCount() passes with correct count", () => {
+    expectSqsDeleteBatchResult(allSuccess).successfulCount(3);
+  });
+
+  await t.step("failedCount() passes with correct count", () => {
+    expectSqsDeleteBatchResult(partialFailure).failedCount(1);
+  });
+
+  await t.step("noFailures() passes when no failures", () => {
+    expectSqsDeleteBatchResult(allSuccess).noFailures();
+  });
+
+  await t.step("chaining works", () => {
+    expectSqsDeleteBatchResult(allSuccess)
+      .ok()
+      .allSuccessful()
+      .successfulCount(3)
+      .noFailures();
+  });
+});
+
+Deno.test("expectSqsMessage", async (t) => {
+  const message: SqsMessage = {
+    messageId: "msg-123",
+    receiptHandle: "receipt-123",
+    body: JSON.stringify({ type: "ORDER", id: 42 }),
+    attributes: {},
+    messageAttributes: {
+      priority: { dataType: "String", stringValue: "high" },
+    },
+    md5OfBody: "abc123",
+  };
+
+  await t.step("bodyContains() passes when body contains substring", () => {
+    expectSqsMessage(message).bodyContains("ORDER");
+  });
+
+  await t.step(
+    "bodyContains() throws when body does not contain substring",
+    () => {
+      assertThrows(
+        () => expectSqsMessage(message).bodyContains("NOTFOUND"),
+        Error,
+        'Expected body to contain "NOTFOUND"',
+      );
+    },
+  );
+
+  await t.step("bodyMatch() calls matcher with body", () => {
+    let called = false;
+    expectSqsMessage(message).bodyMatch((body) => {
+      called = true;
+      assertEquals(typeof body, "string");
+    });
+    assertEquals(called, true);
+  });
+
+  await t.step("bodyJsonEquals() passes with equal JSON", () => {
+    expectSqsMessage(message).bodyJsonEquals({ type: "ORDER", id: 42 });
+  });
+
+  await t.step("bodyJsonEquals() throws with different JSON", () => {
+    assertThrows(
+      () => expectSqsMessage(message).bodyJsonEquals({ type: "DIFFERENT" }),
+      Error,
+      "Expected body JSON to equal",
+    );
+  });
+
+  await t.step("bodyJsonContains() passes when body contains subset", () => {
+    expectSqsMessage(message).bodyJsonContains({ type: "ORDER" });
+  });
+
+  await t.step(
+    "bodyJsonContains() throws when body does not contain subset",
+    () => {
+      assertThrows(
+        () => expectSqsMessage(message).bodyJsonContains({ type: "DIFFERENT" }),
+        Error,
+        "Expected body JSON to contain",
+      );
+    },
+  );
+
+  await t.step("hasAttribute() passes when attribute exists", () => {
+    expectSqsMessage(message).hasAttribute("priority");
+  });
+
+  await t.step("hasAttribute() throws when attribute does not exist", () => {
+    assertThrows(
+      () => expectSqsMessage(message).hasAttribute("nonexistent"),
+      Error,
+      'Expected message to have attribute "nonexistent"',
+    );
+  });
+
+  await t.step("attributesContain() passes with matching attributes", () => {
+    expectSqsMessage(message).attributesContain({
+      priority: { dataType: "String", stringValue: "high" },
+    });
+  });
+
+  await t.step(
+    "attributesContain() throws with non-matching attributes",
+    () => {
+      assertThrows(
+        () =>
+          expectSqsMessage(message).attributesContain({
+            priority: { dataType: "String", stringValue: "low" },
+          }),
+        Error,
+        'Expected attribute "priority" to contain',
+      );
+    },
+  );
+
+  await t.step("messageId() passes with matching id", () => {
+    expectSqsMessage(message).messageId("msg-123");
+  });
+
+  await t.step("messageId() throws with non-matching id", () => {
+    assertThrows(
+      () => expectSqsMessage(message).messageId("wrong-id"),
+      Error,
+      'Expected messageId "wrong-id"',
+    );
+  });
+
+  await t.step("chaining works", () => {
+    expectSqsMessage(message)
+      .bodyContains("ORDER")
+      .bodyJsonContains({ id: 42 })
+      .hasAttribute("priority");
+  });
+});

--- a/packages/probitas-client-sqs/messages.ts
+++ b/packages/probitas-client-sqs/messages.ts
@@ -1,0 +1,39 @@
+import type { SqsMessage, SqsMessages } from "./types.ts";
+
+/**
+ * Create an SqsMessages array with helper methods.
+ */
+export function createSqsMessages(messages: SqsMessage[]): SqsMessages {
+  const arr = [...messages] as SqsMessage[] & {
+    first(): SqsMessage | undefined;
+    firstOrThrow(): SqsMessage;
+    last(): SqsMessage | undefined;
+    lastOrThrow(): SqsMessage;
+  };
+
+  arr.first = function (): SqsMessage | undefined {
+    return this[0];
+  };
+
+  arr.firstOrThrow = function (): SqsMessage {
+    const msg = this[0];
+    if (!msg) {
+      throw new Error("No messages available");
+    }
+    return msg;
+  };
+
+  arr.last = function (): SqsMessage | undefined {
+    return this[this.length - 1];
+  };
+
+  arr.lastOrThrow = function (): SqsMessage {
+    const msg = this[this.length - 1];
+    if (!msg) {
+      throw new Error("No messages available");
+    }
+    return msg;
+  };
+
+  return arr as SqsMessages;
+}

--- a/packages/probitas-client-sqs/mod.ts
+++ b/packages/probitas-client-sqs/mod.ts
@@ -1,0 +1,5 @@
+export type * from "./types.ts";
+export * from "./errors.ts";
+export * from "./client.ts";
+export * from "./messages.ts";
+export * from "./expect.ts";


### PR DESCRIPTION
This commit introduces a new probitas-client-sqs package, providing an SQS client
for sending, receiving, and deleting messages from Amazon SQS queues.

The new package includes:
- SQS client implementation (client.ts)
- Custom error handling (errors.ts)
- Expectation utilities for testing (expect.ts)
- Integration tests (integration_test.ts)
- Message utility functions (messages.ts)
- Type definitions (types.ts)

Also updated:
- .github/workflows/test.yml: Added SQS integration tests.
- CLAUDE.md: Updated documentation.
- compose.yaml: Added SQS service to localstack.
- deno.jsonc: Added SQS package to workspace.
- deno.lock: Updated lock file.
- packages/probitas-client-redis/client.ts: Minor update (unrelated).